### PR TITLE
feat: responsive anime catalog page

### DIFF
--- a/src/api/animes.ts
+++ b/src/api/animes.ts
@@ -120,7 +120,7 @@ export function useFilterAnime(
       sortBy ?? SortBy.TRENDING_DESC,
       format,
       page ?? 1,
-      status
+      status,
     ],
     queryFn: async () => {
       const _query = query ? `&query=${query}` : "";
@@ -150,24 +150,24 @@ export function useFilterAnime(
   });
 }
 
-export function useFetchAnimeInfo(id: string) {
+export function useFetchAnimeInfoAnify(animeId: string){
   return useQuery({
-    queryKey: ["animeInfo", id],
+    queryKey: ["animeInfoAnify", animeId],
     queryFn: async () => {
-      const animeInfoAnilistRes = await axios.get(
-        `${BASE_URL_ANILIST}/info/${id}`
-      );
-      const animeInfoAnifyRes = await axios.get(
-        `https://anify.eltik.cc/info/${id}?fields=[episodes,bannerImage,coverImage,title,rating,trailer,description,type,id,totalEpisodes,year,status,format]`
-      );
-      const animeInfoAnilist = animeInfoAnilistRes.data as AnimeInfoAnilist;
-      const animeInfoAnify = animeInfoAnifyRes.data as AnimeInfoAnify;
-      return { animeInfoAnilist, animeInfoAnify };
-    },
-    refetchInterval: false,
-    refetchIntervalInBackground: false,
-    ...neverRefetchSettings,
-  });
+      const {data: animeInfoAnify} = await axios.get(`https://anify.eltik.cc/info/${animeId}?fields=[episodes,bannerImage,coverImage,title,rating,trailer,description,type,id,totalEpisodes,year,status,format]`)
+      return animeInfoAnify as AnimeInfoAnify
+    }
+  })
+}
+
+export function useFetchAnimeInfoAnilist(animeId: string){
+  return useQuery({
+    queryKey: ["animeInfoAnilist", animeId],
+    queryFn: async () => {
+      const {data: animeInfoAnilist} = await axios.get(`${BASE_URL_ANILIST}/info/${animeId}`)
+      return animeInfoAnilist as AnimeInfoAnilist
+    }
+  })
 }
 
 export function useFetchPopularAnimes(perPage: number) {
@@ -201,30 +201,26 @@ export function useFetchEpisodeStreamLinks(episodeId: string) {
 }
 
 export function useChunkEpisodes(
-  animeInfo:
-    | {
-        animeInfoAnilist: AnimeInfoAnilist;
-        animeInfoAnify: AnimeInfoAnify;
-      }
-    | undefined
+  animeInfoAnilist: AnimeInfoAnilist | undefined,
+  animeInfoAnify: AnimeInfoAnify | undefined
 ) {
   return useQuery({
     queryKey: [
       "chunkedEpisodes",
-      `anify ${animeInfo?.animeInfoAnify?.id}`,
-      `anilist ${animeInfo?.animeInfoAnilist?.id}`,
+      `anify ${animeInfoAnify?.id}`,
+      `anilist ${animeInfoAnilist?.id}`,
     ],
     queryFn: () => {
       const a = chunkEpisodes(
         getEpisodesToBeRendered(
-          animeInfo?.animeInfoAnify,
-          animeInfo?.animeInfoAnilist
+          animeInfoAnify,
+          animeInfoAnilist
         ),
         30
       );
       return a;
     },
-    enabled: !!animeInfo,
+    enabled: !!animeInfoAnify || !!animeInfoAnilist,
     refetchInterval: false,
     refetchIntervalInBackground: false,
     ...neverRefetchSettings,

--- a/src/api/animes.ts
+++ b/src/api/animes.ts
@@ -16,6 +16,7 @@ import {
   chunkEpisodes,
   getEpisodesToBeRendered,
 } from "@/utils/functions/reusable_functions";
+import { AnimeInfoAnizip } from "@/utils/types/animeAnizip";
 
 const BASE_URL_ANILIST = "https://consumet-api-raves.vercel.app/meta/anilist";
 
@@ -183,6 +184,16 @@ export function useFetchPopularAnimes(perPage: number) {
     refetchIntervalInBackground: false,
     ...neverRefetchSettings,
   });
+}
+
+export function useFetchAnimeInfoAnizip(animeId: string) {
+  return useQuery({
+    queryKey: ["animeInfoAnizip", animeId],
+    queryFn: async () => {
+      const {data: animeInfoAnizip} = await axios.get(`https://api.ani.zip/mappings?anilist_id=${animeId}`)
+      return animeInfoAnizip as AnimeInfoAnizip
+    }
+  })
 }
 
 export function useFetchEpisodeStreamLinks(episodeId: string) {

--- a/src/components/global/GlobalDialog.tsx
+++ b/src/components/global/GlobalDialog.tsx
@@ -1,8 +1,5 @@
 import { useGlobalStore } from "@/utils/stores/globalStore";
-import {
-  Dialog,
-  DialogPanel,
-} from "@headlessui/react";
+import { Dialog, DialogPanel } from "@headlessui/react";
 import { useShallow } from "zustand/react/shallow";
 
 export default function GlobalDialog() {
@@ -18,10 +15,9 @@ export default function GlobalDialog() {
     <Dialog
       open={isDialogOpen}
       onClose={() => toggleOpenDialog(null)}
-      className="relative z-[99999999]"
+      className="relative z-[200]"
     >
-      <div className="fixed inset-0 w-dvw bg-black/85 backdrop-blur-[1px]"></div>
-      <div className="fixed inset-0 grid overflow-x-hidden overflow-y-auto place-items-center font-montserrat">
+      <div className="fixed font-montserrat inset-0 grid place-items-center w-dvw overflow-x-hidden hide-scrollbar overflow-y-auto bg-black/85 backdrop-blur-[1px]">
         <DialogPanel
           transition
           className="duration-150 ease-out data-[closed]:scale-95 data-[closed]:opacity-0"

--- a/src/routes/anime/$animeId/index.tsx
+++ b/src/routes/anime/$animeId/index.tsx
@@ -1,10 +1,14 @@
-import { useChunkEpisodes, useFetchAnimeInfo } from "@/api/animes";
+import {
+  useChunkEpisodes,
+  useFetchAnimeInfoAnify,
+  useFetchAnimeInfoAnilist,
+} from "@/api/animes";
 import { createFileRoute } from "@tanstack/react-router";
 import AnimeHeroComponent from "../-AnimeHeroComponent";
 import Episodes from "./-Episodes";
 import { useEffect } from "react";
 import AnimeCategoryCarousel from "../-AnimeCategoryCarousel";
-import { Status } from "@/utils/types/animeAnilist";
+import { Format, Status } from "@/utils/types/animeAnilist";
 export const Route = createFileRoute("/anime/$animeId/")({
   component: () => <AnimeInfo />,
 });
@@ -13,19 +17,28 @@ function AnimeInfo() {
   const { animeId } = Route.useParams();
 
   const {
-    data: animeInfo,
-    isLoading: isAnimeInfoLoading,
-    error: animeInfoError,
-  } = useFetchAnimeInfo(animeId);
+    data: animeInfoAnify,
+    isLoading: isAnimeInfoAnifyLoading,
+    error: animeInfoAnifyError,
+  } = useFetchAnimeInfoAnify(animeId);
+  const {
+    data: animeInfoAnilist,
+    isLoading: isAnimeInfoAnilistLoading,
+    error: animeInfoAnilistError,
+  } = useFetchAnimeInfoAnilist(animeId);
 
   const { data: chunkedEpisodes, isLoading: isChunkEpisodesLoading } =
-    useChunkEpisodes(animeInfo);
+    useChunkEpisodes(animeInfoAnilist, animeInfoAnify);
 
   useEffect(() => {
     window.scrollTo(0, 0);
   }, []);
 
-  if (isAnimeInfoLoading || isChunkEpisodesLoading) {
+  if (
+    isAnimeInfoAnifyLoading ||
+    isAnimeInfoAnilistLoading ||
+    isChunkEpisodesLoading
+  ) {
     return (
       <div className="grid text-2xl text-white bg-darkBg h-dvh place-items-center">
         <p>
@@ -36,7 +49,7 @@ function AnimeInfo() {
     );
   }
 
-  if (animeInfoError) {
+  if (animeInfoAnifyError && animeInfoAnilistError) {
     return (
       <div className="flex flex-col items-center justify-center h-screen bg-darkBg">
         <p>Oops! There was an error fetching the details for this anime.</p>
@@ -44,55 +57,58 @@ function AnimeInfo() {
       </div>
     );
   }
-  
-  if (animeInfo) {
-    const { animeInfoAnilist, animeInfoAnify } = animeInfo;
+
+  if (animeInfoAnify || animeInfoAnilist) {
     return (
       <main className="w-full pb-32">
         <AnimeHeroComponent
+          animeId={animeId}
           title={
-            animeInfoAnify.title.english ??
-            animeInfoAnify.title.romaji ??
-            animeInfoAnilist.title.english ??
-            animeInfoAnilist.title.romaji
+            animeInfoAnify?.title.english ??
+            animeInfoAnify?.title.romaji ??
+            animeInfoAnilist?.title.english ??
+            animeInfoAnilist?.title.romaji
           }
-          cover={animeInfoAnify.bannerImage ?? animeInfoAnilist.cover}
-          image={animeInfoAnilist.image ?? animeInfoAnify.coverImage}
-          id={animeInfoAnilist.id ?? animeInfoAnify.id}
+          cover={animeInfoAnify?.bannerImage ?? animeInfoAnilist?.cover}
+          image={animeInfoAnilist?.image ?? animeInfoAnify?.coverImage}
+          id={animeInfoAnilist?.id ?? animeInfoAnify?.id}
           description={
-            animeInfoAnilist.description ?? animeInfoAnify.description
+            animeInfoAnilist?.description ?? animeInfoAnify?.description
           }
-          genres={animeInfoAnilist.genres}
-          status={animeInfoAnilist.status ?? animeInfoAnify.status as Status}
+          genres={animeInfoAnilist?.genres}
+          status={
+            animeInfoAnilist?.status ?? (animeInfoAnify?.status as Status)
+          }
           totalEpisodes={
-            animeInfoAnify.totalEpisodes ?? animeInfoAnilist.totalEpisodes
+            animeInfoAnify?.totalEpisodes ?? animeInfoAnilist?.totalEpisodes
           }
-          type={animeInfoAnilist.type ?? animeInfoAnify.format}
-          year={animeInfoAnilist.releaseDate ?? animeInfoAnify.year}
+          type={animeInfoAnilist?.type ?? (animeInfoAnify?.format as Format)}
+          year={animeInfoAnilist?.releaseDate ?? animeInfoAnify?.year}
           rating={
-            animeInfoAnify.rating.anilist ??
-            animeInfoAnilist.rating! * 0.1 ??
+            animeInfoAnify?.rating.anilist ??
+            animeInfoAnilist?.rating! * 0.1 ??
             null
           }
         />
         <Episodes
           isInfoPage
-          animeId={animeInfoAnify.id ?? animeInfoAnilist.id}
+          animeId={animeInfoAnify?.id ?? animeInfoAnilist?.id}
           chunkedEpisodes={chunkedEpisodes}
           replace={false}
-          type={animeInfoAnilist.type ?? animeInfoAnify.format}
+          type={animeInfoAnilist?.type ?? animeInfoAnify?.format}
           defaultEpisodeImage={
-            animeInfoAnify.coverImage ?? animeInfoAnilist.cover
+            animeInfoAnify?.coverImage ?? animeInfoAnilist?.cover
           }
         />
-        {animeInfoAnilist.recommendations && (
-          <AnimeCategoryCarousel
-            isInfoPage
-            isHomePage={false}
-            recommendations={animeInfoAnilist.recommendations}
-            categoryName="Recommendations"
-          />
-        )}
+        {animeInfoAnilist?.recommendations &&
+          animeInfoAnilist?.recommendations.length !== 0 && (
+            <AnimeCategoryCarousel
+              isInfoPage
+              isHomePage={false}
+              recommendations={animeInfoAnilist?.recommendations}
+              categoryName="Recommendations"
+            />
+          )}
       </main>
     );
   }

--- a/src/routes/anime/$animeId/watch/index.tsx
+++ b/src/routes/anime/$animeId/watch/index.tsx
@@ -1,13 +1,11 @@
 import {
   useChunkEpisodes,
   useEpisodeInfo,
-  useFetchAnimeInfo,
+  useFetchAnimeInfoAnilist,
+  useFetchAnimeInfoAnify,
   useFetchEpisodeStreamLinks,
 } from "@/api/animes";
-import {
-  createFileRoute,
-  useNavigate
-} from "@tanstack/react-router";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useEffect, useRef } from "react";
 import "@vidstack/react/player/styles/default/theme.css";
 import "@vidstack/react/player/styles/default/layouts/video.css";
@@ -57,32 +55,38 @@ function EpisodePage() {
   } = useFetchEpisodeStreamLinks(id);
 
   const {
-    data: animeInfo,
-    isLoading: isAnimeInfoLoading,
-    error: animeInfoError,
-  } = useFetchAnimeInfo(animeId);
+    data: animeInfoAnify,
+    isLoading: isAnimeInfoAnifyLoading,
+    error: animeInfoAnifyError,
+  } = useFetchAnimeInfoAnify(animeId);
+  const {
+    data: animeInfoAnilist,
+    isLoading: isAnimeInfoAnilistLoading,
+    error: animeInfoAnilistError,
+  } = useFetchAnimeInfoAnilist(animeId);
 
-  const { data: chunkedEpisodes } = useChunkEpisodes(animeInfo);
+  const { data: chunkedEpisodes } = useChunkEpisodes(
+    animeInfoAnilist,
+    animeInfoAnify
+  );
 
   const { data: episodeInfo } = useEpisodeInfo(id, chunkedEpisodes);
 
-  if (isEpisodeStreamLinksLoading || isAnimeInfoLoading) {
+  if (
+    isEpisodeStreamLinksLoading ||
+    isAnimeInfoAnilistLoading ||
+    isAnimeInfoAnifyLoading
+  ) {
     return (
       <div className="grid text-2xl text-white h-dvh place-items-center">
         <p>
           LOADING&nbsp;
-          <span className="font-semibold text-red-500">
-            {isEpisodeStreamLinksLoading && isAnimeInfoLoading
-              ? "ALL"
-              : isEpisodeStreamLinksLoading
-                ? "EPISODE"
-                : "ANIME INFO"}
-          </span>
+          <span className="font-semibold text-red-500">EPISODE</span>
         </p>
       </div>
     );
   }
-  if (episodeStreamLinksError || animeInfoError) {
+  if (episodeStreamLinksError && animeInfoAnifyError && animeInfoAnilistError) {
     return (
       <div className="flex flex-col items-center justify-center h-screen bg-darkBg">
         <p>Oops! There was an error fetching this episode.</p>
@@ -91,8 +95,7 @@ function EpisodePage() {
     );
   }
 
-  if (episodeStreamLinks && animeInfo) {
-    const { animeInfoAnilist, animeInfoAnify } = animeInfo;
+  if (episodeStreamLinks && (animeInfoAnify || animeInfoAnilist)) {
     return (
       <div className="flex flex-col pb-32">
         <div className="flex flex-col w-full gap-2 pt-20 lg:pt-24 lg:gap-6 lg:flex-row lg:px-16">
@@ -121,9 +124,9 @@ function EpisodePage() {
             <div className="w-full px-2 mt-2 sm:px-3 lg:px-0">
               <div className="flex flex-col gap-1">
                 <p className="text-lg font-bold sm:text-xl line-clamp-1">
-                  {animeInfoAnilist.title && animeInfoAnify.title
-                    ? animeInfoAnilist.title.english ??
-                      animeInfoAnify.title.english
+                  {animeInfoAnilist?.title && animeInfoAnify?.title
+                    ? animeInfoAnilist?.title.english ??
+                      animeInfoAnify?.title.english
                     : ""}
                 </p>
                 <p className="text-lg font-semibold text-gray-400 sm:text-xl">
@@ -148,12 +151,12 @@ function EpisodePage() {
             }
           />
         </div>
-        {animeInfoAnilist.recommendations && (
+        {animeInfoAnilist?.recommendations && (
           <AnimeCategoryCarousel
             isInfoPage={false}
             isHomePage={false}
             categoryName="Recommendations"
-            recommendations={animeInfoAnilist.recommendations}
+            recommendations={animeInfoAnilist?.recommendations}
           />
         )}
       </div>

--- a/src/routes/anime/-AnimeCard.tsx
+++ b/src/routes/anime/-AnimeCard.tsx
@@ -19,10 +19,7 @@ type AnimeCardProps = {
 export default function AnimeCard(props: AnimeCardProps) {
   if (props.isHomePage) {
     return (
-      <Link
-        to={`/anime/${props.anime.id}`}
-        className="space-y-2 group"
-      >
+      <Link to={`/anime/${props.anime.id}`} className="space-y-2 group">
         <div
           className={cn(
             "relative aspect-[3/4] overflow-hidden bg-gray-600 rounded-md lg:rounded-xl",
@@ -31,53 +28,47 @@ export default function AnimeCard(props: AnimeCardProps) {
         >
           {props.anime.image && (
             <>
-              <div className="absolute z-10 hidden transition-all opacity-0 lg:grid place-items-center size-full bg-mainAccent/40 group-hover:opacity-100">
+              {/* <div className="absolute z-10 hidden transition-all duration-300 opacity-0 lg:grid place-items-center size-full bg-mainAccent/40 group-hover:opacity-100">
                 <div className="grid bg-white rounded-full size-12 place-items-center">
                   <svg
-                    className="size-[50%]"
-                    fill="#c026d3"
+                    className="size-[50%] fill-mainAccent"
                     xmlns="http://www.w3.org/2000/svg"
                     viewBox="0 0 384 512"
                   >
                     <path d="M73 39c-14.8-9.1-33.4-9.4-48.5-.9S0 62.6 0 80V432c0 17.4 9.4 33.4 24.5 41.9s33.7 8.1 48.5-.9L361 297c14.3-8.7 23-24.2 23-41s-8.7-32.2-23-41L73 39z" />
                   </svg>
                 </div>
-              </div>
+              </div> */}
+              <div className="absolute inset-0 z-10 transition-all duration-300 opacity-0 group-hover:opacity-100 size-full bg-mainAccent/40"></div>
               <img
                 loading="lazy"
                 src={props.anime.image}
-                className="object-cover transition-all size-full group-hover:scale-105"
+                className="object-cover transition-all duration-300 size-full group-hover:scale-105"
                 alt={props.anime.title.english}
               />
             </>
           )}
         </div>
         <div className="space-y-1">
-          <p className="text-sm font-medium text-[#E0E0E0] line-clamp-2">
+          <p className="text-xs mobile-l:text-sm font-medium text-[#E0E0E0] line-clamp-2">
             {props.anime.title.english ?? props.anime.title.romaji}
           </p>
           <div className="flex items-center gap-2 text-xs text-gray-400">
-            {props.anime.status === Status.NotYetAired ||
-            props.anime.status === Status.NOT_YET_RELEASED ? (
+            {[Status.NotYetAired, Status.NOT_YET_RELEASED].includes(
+              props.anime.status
+            ) ? (
               <p className="line-clamp-1">Not yet aired</p>
+            ) : [Status.CANCELLED, Status.Cancelled].includes(
+                props.anime.status
+              ) ? (
+              <p className="line-clamp-1">Cancelled</p>
             ) : (
               <>
-                <p>{props.anime.releaseDate}</p>
-                <div className="bg-gray-400 rounded-full size-1"></div>
-                {props.anime.type === "MOVIE" ? (
-                  <p className="line-clamp-1">MOVIE</p>
-                ) : (
-                  <>
-                    <p className="line-clamp-1 lg:hidden">
-                      {props.anime.totalEpisodes}{" "}
-                      {props.anime.totalEpisodes === 1 ? "ep" : "eps"}
-                    </p>
-                    <p className="hidden line-clamp-1 lg:block">
-                      {props.anime.totalEpisodes}{" "}
-                      {props.anime.totalEpisodes === 1 ? "episode" : "episodes"}
-                    </p>
-                  </>
+                {props.anime.type && <p>{props.anime.type}</p>}
+                {props.anime.releaseDate && props.anime.type && (
+                  <div className="bg-gray-400 rounded-full size-1"></div>
                 )}
+                {props.anime.releaseDate && <p>{props.anime.releaseDate}</p>}
               </>
             )}
           </div>

--- a/src/routes/anime/-AnimeCategoryCarousel.tsx
+++ b/src/routes/anime/-AnimeCategoryCarousel.tsx
@@ -35,7 +35,7 @@ export default function AnimeCategoryCarousel(
   if (props.isHomePage) {
     return (
       <div className="w-full px-3 pt-5 space-y-6 text-gray-400 lg:px-16 sm:px-6">
-        <div className="flex justify-between w-full">
+        <div className="flex items-center justify-between w-full">
           <p className="text-lg font-semibold sm:text-xl lg:text-2xl">
             {props.categoryName}
           </p>
@@ -44,7 +44,7 @@ export default function AnimeCategoryCarousel(
             search={{
               sortBy: props.seeAllSortBy,
             }}
-            className="flex items-center gap-1 px-2 py-1 transition-all duration-300 border border-gray-400 rounded-full sm:px-3 sm:py-2 lg:px-4 group hover:border-mainAccent"
+            className="flex items-center gap-1 px-3 py-2 transition-all duration-300 border border-gray-400 rounded-full lg:px-4 group hover:border-mainAccent"
           >
             <p className="text-xs transition-all duration-300 md:text-base group-hover:text-mainAccent whitespace-nowrap">
               See All

--- a/src/routes/anime/-AnimeHeroComponent.tsx
+++ b/src/routes/anime/-AnimeHeroComponent.tsx
@@ -4,6 +4,8 @@ import { motion } from "framer-motion";
 import { useNavigate } from "@tanstack/react-router";
 import { Format, Genre, Status } from "@/utils/types/animeAnilist";
 import { Link } from "@tanstack/react-router";
+import { getRatingScore } from "@/utils/functions/reusable_functions";
+import { cn } from "@/lib/utils";
 
 type AnimeHeroComponentProps = {
   image?: string;
@@ -18,13 +20,9 @@ type AnimeHeroComponentProps = {
   trendingRank?: number;
   genres?: Genre[];
   rating?: number | null;
+  firstEpisodeId?: string;
+  animeId: string;
 };
-
-function getRatingScore(rating: number) {
-  const decimal = (rating * 10).toString().split(".")[1];
-  if (!decimal || decimal.length < 1) return (0.05 * (rating * 10)).toFixed(1);
-  return (0.05 * (rating * 10)).toFixed(2);
-}
 
 export default function AnimeHeroComponent({
   image,
@@ -37,14 +35,14 @@ export default function AnimeHeroComponent({
   status,
   genres,
   rating,
-  // id,
+  firstEpisodeId,
+  animeId,
 }: AnimeHeroComponentProps) {
   const [starsFillWidthPercentage, setStarsFillWidthPercentage] = useState(0);
   const starsFillWidthRef = useRef<HTMLDivElement | null>(null);
   const [readMore, setReadMore] = useState(false);
   const [descriptionHeight, setDescriptionHeight] = useState(0);
   const descriptionRef = useRef<HTMLParagraphElement | null>(null);
-
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -117,11 +115,26 @@ export default function AnimeHeroComponent({
               </div>
               <div className="flex gap-2">
                 <p className="text-gray-400">Status:</p>
-                <p
-                  className={`${status === Status.RELEASING || status === Status.Ongoing ? "text-green-500" : status === Status.FINISHED || status === Status.Completed ? "text-blue-500" : "text-orange-500"} font-semibold`}
-                >
-                  {status}
-                </p>
+                {status && (
+                  <p
+                    className={cn("font-semibold text-orange-500", {
+                      "text-green-500": [
+                        Status.Ongoing,
+                        Status.RELEASING,
+                      ].includes(status),
+                      "text-blue-500": [
+                        Status.FINISHED,
+                        Status.Completed,
+                      ].includes(status),
+                      "text-red-500": [
+                        Status.CANCELLED,
+                        Status.Cancelled,
+                      ].includes(status),
+                    })}
+                  >
+                    {status}
+                  </p>
+                )}
               </div>
               <div className="flex gap-2">
                 <p className="text-gray-400">Type:</p>
@@ -150,19 +163,33 @@ export default function AnimeHeroComponent({
           <div className="flex items-center gap-2 lg:hidden">
             <p>{year}</p>
             <div className="bg-gray-400 rounded-full size-1"></div>
-            <p
-              className={`${status === Status.RELEASING || status === Status.Ongoing ? "text-green-500" : status === Status.FINISHED || status === Status.Completed ? "text-blue-500" : "text-orange-500"}`}
-            >
-              {status}
-            </p>
+            {status && (
+              <p
+                className={cn("font-semibold text-orange-500", {
+                  "text-green-500": [Status.Ongoing, Status.RELEASING].includes(
+                    status
+                  ),
+                  "text-blue-500": [Status.FINISHED, Status.Completed].includes(
+                    status
+                  ),
+                  "text-red-500": [Status.CANCELLED, Status.Cancelled].includes(
+                    status
+                  ),
+                })}
+              >
+                {status}
+              </p>
+            )}
           </div>
           <div className="flex gap-5 my-3">
             <motion.button
               onClick={() => {
-                navigate({
-                  to: "/anime/$animeId",
-                  params: { animeId: "1535" },
-                });
+                firstEpisodeId &&
+                  navigate({
+                    to: "/anime/$animeId/watch",
+                    params: { animeId: animeId },
+                    search: { id: firstEpisodeId.replace(/^\//, "") },
+                  });
               }}
               whileHover={{ scale: 1.03 }}
               transition={{ duration: 0.2 }}
@@ -251,11 +278,26 @@ export default function AnimeHeroComponent({
               </div>
               <div className="flex gap-2">
                 <p className="text-gray-400">Status:</p>
-                <p
-                  className={`${status === Status.RELEASING || status === Status.Ongoing ? "text-green-500" : status === Status.FINISHED || status === Status.Completed ? "text-blue-500" : "text-orange-500"} font-semibold `}
-                >
-                  {status}
-                </p>
+                {status && (
+                  <p
+                    className={cn("font-semibold text-orange-500", {
+                      "text-green-500": [
+                        Status.Ongoing,
+                        Status.RELEASING,
+                      ].includes(status),
+                      "text-blue-500": [
+                        Status.FINISHED,
+                        Status.Completed,
+                      ].includes(status),
+                      "text-red-500": [
+                        Status.CANCELLED,
+                        Status.Cancelled,
+                      ].includes(status),
+                    })}
+                  >
+                    {status}
+                  </p>
+                )}
               </div>
               <div className="flex gap-2">
                 <p className="text-gray-400">Type:</p>

--- a/src/routes/anime/-SearchDialogResultCard.tsx
+++ b/src/routes/anime/-SearchDialogResultCard.tsx
@@ -1,28 +1,72 @@
+import { getRatingScore } from "@/utils/functions/reusable_functions";
 import { useGlobalStore } from "@/utils/stores/globalStore";
-import { Anime } from "@/utils/types/animeAnilist";
+import { Anime, Status } from "@/utils/types/animeAnilist";
+import { statusLabels } from "@/utils/variables/anime";
 import { Link } from "@tanstack/react-router";
+import { Star } from "lucide-react";
 
 type SearchResultCardProps = {
   anime: Anime;
 };
 
-export default function SearchDialogResultCard({ anime }: SearchResultCardProps) {
+export default function SearchDialogResultCard({
+  anime,
+}: SearchResultCardProps) {
   const { toggleOpenDialog } = useGlobalStore();
   return (
     <Link
       to={`/anime/${anime.id}`}
       onClick={() => toggleOpenDialog(null)}
-      className="flex w-full gap-4 px-3 py-2"
+      className="flex w-full gap-4 px-3 py-2 hover:bg-gray-900/70"
     >
       <img
         src={anime.image}
         alt={anime.title.english ?? anime.title.romaji}
         className="object-cover size-full aspect-[3/4] w-[80px] rounded-md"
       />
-      <div className="flex flex-col gap-3">
+      <div className="flex flex-col justify-center w-full gap-3">
         <p className="text-lg font-semibold">
           {anime.title.english ?? anime.title.romaji}
         </p>
+        <div className="w-full space-y-3 text-sm text-gray-400">
+          <div className="flex items-center gap-[6px]">
+            {![
+              Status.CANCELLED,
+              Status.NOT_YET_RELEASED,
+              Status.NotYetAired,
+            ].includes(anime.status) && (
+              <>
+                <p>
+                  {anime.totalEpisodes}&nbsp;
+                  {anime.totalEpisodes > 1 ? "episodes" : "episode"}
+                </p>
+                <div className="bg-gray-400 rounded-full size-1" />
+              </>
+            )}
+            <p>{statusLabels[anime.status]}</p>
+          </div>
+          {![
+            Status.CANCELLED,
+            Status.NOT_YET_RELEASED,
+            Status.NotYetAired,
+          ].includes(anime.status) && (
+            <div className="flex items-center gap-[6px]">
+              {anime.releaseDate && (
+                <>
+                  <p>{anime.releaseDate}</p>
+                  <div className="bg-gray-400 rounded-full size-1" />
+                </>
+              )}
+              <p>{anime.type}</p>
+              <div className="bg-gray-400 rounded-full size-1" />
+
+              <div className="flex items-center gap-1">
+                <Star className="size-4" />
+                <p>{getRatingScore(anime.rating * 0.1)}</p>
+              </div>
+            </div>
+          )}
+        </div>
       </div>
     </Link>
   );

--- a/src/routes/anime/catalog/-AppliedFilterPill.tsx
+++ b/src/routes/anime/catalog/-AppliedFilterPill.tsx
@@ -9,7 +9,7 @@ type FilterPillProps = {
 
 export default function AppliedFilterPill({className, label} : FilterPillProps) {
     return (
-        <div className={cn("px-4 py-2 flex gap-3 rounded-full items-center", className)}>
+        <div className={cn("px-4 py-2 flex gap-3 rounded-full whitespace-nowrap text-xs md:text-sm lg:text-base items-center", className)}>
             <p>{label}</p>
             {/* <X className="size-4" onClick={onDelete}/> */}
         </div>

--- a/src/routes/anime/catalog/-AppliedFilters.tsx
+++ b/src/routes/anime/catalog/-AppliedFilters.tsx
@@ -8,23 +8,17 @@ import {
 } from "@/utils/variables/anime";
 
 export default function AppliedFilters() {
-  const {
-    genres,
-    query,
-    format,
-    season,
-    sortBy,
-    year,
-    status,
-  } = useSearch({
+  const { genres, query, format, season, sortBy, year, status } = useSearch({
     from: "/anime/catalog/",
   });
 
   return (
-    <div className="flex flex-wrap w-full gap-4">
+    <div className="flex w-full gap-4 overflow-x-auto hide-scrollbar sm:overflow-x-visible sm:flex-wrap">
       {query && (
         <div className="space-y-2">
-          <p className="font-medium text-gray-400">Query</p>
+          <p className="text-xs font-medium text-gray-400 lg:text-base sm:text-sm">
+            Query
+          </p>
           <AppliedFilterPill
             className="text-white rounded-full bg-emerald-500"
             label={query}
@@ -34,12 +28,14 @@ export default function AppliedFilters() {
       )}
       {genres && (
         <div className="space-y-2">
-          <p className="font-medium text-gray-400">Genres</p>
-          <div className="flex flex-wrap items-center gap-2">
+          <p className="text-xs font-medium text-gray-400 lg:text-base sm:text-sm">
+            Genres
+          </p>
+          <div className="flex items-center gap-2 overflow-x-auto sm:flex-wrap">
             {genres.split(",").map((genre) => (
               <AppliedFilterPill
                 key={genre}
-                className="text-white rounded-full bg-sky-500"
+                className="text-white bg-blue-500 rounded-full"
                 label={genre}
                 onDelete={() => {}}
               />
@@ -49,7 +45,9 @@ export default function AppliedFilters() {
       )}
       {sortBy && (
         <div className="space-y-2">
-          <p className="font-medium text-gray-400">Sort By</p>
+          <p className="text-xs font-medium text-gray-400 lg:text-base sm:text-sm">
+            Sort By
+          </p>
           <AppliedFilterPill
             className="text-white bg-pink-600 rounded-full"
             label={sortByLabels[sortBy]}
@@ -57,29 +55,11 @@ export default function AppliedFilters() {
           />
         </div>
       )}
-      {status && (
-        <div className="space-y-2">
-          <p className="font-medium text-gray-400">Sort By</p>
-          <AppliedFilterPill
-            className="text-white bg-pink-600 rounded-full"
-            label={anilistAnimeStatusLabels[status]}
-            onDelete={() => {}}
-          />
-        </div>
-      )}
-      {year && (
-        <div className="space-y-2">
-          <p className="font-medium text-gray-400">Year</p>
-          <AppliedFilterPill
-            className="text-white bg-indigo-500 rounded-full"
-            label={year.toString()}
-            onDelete={() => {}}
-          />
-        </div>
-      )}
       {format && (
         <div className="space-y-2">
-          <p className="font-medium text-gray-400">Format</p>
+          <p className="text-xs font-medium text-gray-400 lg:text-base sm:text-sm">
+            Format
+          </p>
           <AppliedFilterPill
             className="text-white bg-orange-500 rounded-full"
             label={formatLabels[format]}
@@ -87,9 +67,35 @@ export default function AppliedFilters() {
           />
         </div>
       )}
+      {status && (
+        <div className="space-y-2">
+          <p className="text-xs font-medium text-gray-400 lg:text-base sm:text-sm">
+            Status
+          </p>
+          <AppliedFilterPill
+            className="text-white rounded-full bg-lime-600"
+            label={anilistAnimeStatusLabels[status]}
+            onDelete={() => {}}
+          />
+        </div>
+      )}
+      {year && (
+        <div className="space-y-2">
+          <p className="text-xs font-medium text-gray-400 lg:text-base sm:text-sm">
+            Year
+          </p>
+          <AppliedFilterPill
+            className="text-white rounded-full bg-sky-500"
+            label={year.toString()}
+            onDelete={() => {}}
+          />
+        </div>
+      )}
       {season && (
         <div className="space-y-2">
-          <p className="font-medium text-gray-400">Season</p>
+          <p className="text-xs font-medium text-gray-400 lg:text-base sm:text-sm">
+            Season
+          </p>
           <AppliedFilterPill
             className="text-white bg-teal-500 rounded-full"
             label={seasonLabels[season]}

--- a/src/routes/anime/catalog/-CatalogAnimeList.tsx
+++ b/src/routes/anime/catalog/-CatalogAnimeList.tsx
@@ -7,9 +7,9 @@ type CatalogAnimeList = {
 
 export default function CatalogAnimeList({ animeList }: CatalogAnimeList) {
   return (
-    <div className="grid w-full grid-cols-6 gap-x-5 gap-y-6">
+    <div className="grid w-full grid-cols-3 sm:grid-cols-4 lg:grid-cols-5 gap-x-3 gap-y-4 xl:grid-cols-6 lg:gap-x-5 lg:gap-y-6">
       {animeList.map((anime, i) => (
-        <AnimeCard key={anime.id ?? i} anime={anime} isHomePage />
+        <AnimeCard key={anime.id ?? i} anime={anime} isHomePage/>
       ))}
     </div>
   );

--- a/src/routes/anime/catalog/-FilterDropdown.tsx
+++ b/src/routes/anime/catalog/-FilterDropdown.tsx
@@ -29,7 +29,7 @@ export default function FilterDropdown<T>({
     <div className="relative" ref={parentDivRef}>
       <button
         onClick={() => setIsOpen(!isOpen)}
-        className="flex items-center gap-3 px-4 py-2 border border-gray-400 rounded-full z-[100]"
+        className="flex items-center gap-3 px-4 lg:px-5 py-2 border border-gray-400 rounded-full z-[100]"
       >
         <p className="font-medium text-mainAccent">
           {currentlySelected
@@ -46,7 +46,7 @@ export default function FilterDropdown<T>({
             duration: 0.3,
           }}
         >
-          <ChevronDown className="size-6 stroke-gray-400" />
+          <ChevronDown className="size-4 md:size-6 stroke-gray-400" />
         </motion.div>
       </button>
       <motion.div
@@ -68,8 +68,8 @@ export default function FilterDropdown<T>({
           }
         }}
         className={cn(
-          "absolute w-fit overflow-x-hidden top-[50px] right-0 max-h-[300px] rounded-lg bg-black overflow-y-auto",
-          dropdownMenuListHeight! < 300 && "hide-scrollbar"
+          "absolute w-fit z-10 overflow-x-hidden top-[50px] right-0 max-h-[250px] rounded-lg bg-black overflow-y-auto",
+          dropdownMenuListHeight! < 250 && "hide-scrollbar"
         )}
       >
         {itemList.map((item, i) => (
@@ -79,7 +79,15 @@ export default function FilterDropdown<T>({
               onSelectItem(item);
               setIsOpen(false);
             }}
-            className="w-full px-3 py-2 text-gray-400 text-start hover:text-mainAccent whitespace-nowrap"
+            className={cn(
+              "w-full px-3 py-2 text-gray-400 text-start hover:text-mainAccent whitespace-nowrap",
+              {
+                "text-mainAccent":
+                  (labelMap &&
+                    labelMap[currentlySelected as string] === item) ||
+                  currentlySelected === item,
+              }
+            )}
           >
             {`${labelMap ? labelMap[item as string] : item}`}
           </button>

--- a/src/routes/anime/catalog/-FilterPill.tsx
+++ b/src/routes/anime/catalog/-FilterPill.tsx
@@ -4,21 +4,25 @@ import { cn } from "@/lib/utils";
 type FilterPillProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
   isSelected: boolean;
   label: string;
+  className?: string
 };
 
 export default function FilterPill({
   isSelected,
   label,
+  className,
   ...props
 }: FilterPillProps) {
   return (
     <button
       {...props}
       className={cn(
+       
         `px-5 py-3 rounded-full border transition-colors duration-200`,
         isSelected
           ? "text-white bg-mainAccent border-mainAccent"
-          : "text-gray-400 bg-transparent border-gray-400"
+          : "text-gray-400 bg-transparent border-gray-400",
+        className,
       )}
     >
       {label}

--- a/src/routes/anime/catalog/-FiltersDialog.tsx
+++ b/src/routes/anime/catalog/-FiltersDialog.tsx
@@ -6,7 +6,6 @@ import {
   Season,
   SortBy,
 } from "@/utils/types/animeAnilist";
-import { X } from "lucide-react";
 import FilterPill from "./-FilterPill";
 import { useState } from "react";
 import FilterDropdown from "./-FilterDropdown";
@@ -18,6 +17,7 @@ import {
 } from "@/utils/variables/anime";
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import { isEqual } from "radash";
+import { X } from "lucide-react";
 
 const genres = Object.values(Genre);
 const formats = Object.values(Format);
@@ -32,10 +32,10 @@ const years = Array.from({ length: endYear - startYear + 1 }).map(
 
 type Filters = {
   sortBy: SortBy;
-  format: Format | undefined;
-  status: AnilistAnimeStatus | undefined;
-  season: Season | undefined;
-  year: number | undefined;
+  format?: Format;
+  status?: AnilistAnimeStatus;
+  season?: Season;
+  year?: number;
   genres: Genre[] | [];
 };
 
@@ -71,13 +71,13 @@ export default function FiltersDialog() {
   );
 
   const [initialFilters] = useState<Filters>({
-    format: selectedFormat, 
+    format: selectedFormat,
     genres: selectedGenres,
     season: selectedSeason,
     sortBy: selectedSortBy,
     status: selectedStatus,
-    year: selectedYear
-  })
+    year: selectedYear,
+  });
 
   function selectGenre(genre: Genre) {
     setSelectedGenres([...selectedGenres, genre]);
@@ -129,94 +129,99 @@ export default function FiltersDialog() {
 
   return (
     <div className="max-w-full w-dvw bg-black/50">
-      <div className="w-[1312px] mx-auto min-h-screen text-white flex flex-col py-12 gap-6">
-        <header className="flex items-center justify-between w-full">
-          <div className="flex gap-6">
-            <div className="relative flex items-center gap-4">
-              <p className="text-gray-400">Sort By:</p>
-              <FilterDropdown
-                itemList={sortBys}
-                onSelectItem={(sortBy) => setSelectedSortBy(sortBy)}
-                labelMap={sortByLabels}
-                currentlySelected={selectedSortBy}
-              />
-            </div>
-            <div className="relative flex items-center gap-4">
-              <p className="text-gray-400">Type:</p>
-              <FilterDropdown
-                itemList={formats}
-                onSelectItem={(format) => setSelectedFormat(format)}
-                labelMap={formatLabels}
-                currentlySelected={selectedFormat}
-              />
-            </div>
-            <div className="relative flex items-center gap-4">
-              <p className="text-gray-400">Status:</p>
-              <FilterDropdown
-                itemList={statuses}
-                labelMap={anilistAnimeStatusLabels}
-                onSelectItem={(status) => setSelectedStatus(status)}
-                currentlySelected={selectedStatus}
-              />
-            </div>
-            <div className="relative flex items-center gap-4">
-              <p className="text-gray-400">Season:</p>
-              <FilterDropdown
-                itemList={seasons}
-                onSelectItem={(season) => setSelectedSeason(season)}
-                labelMap={seasonLabels}
-                currentlySelected={selectedSeason}
-              />
-            </div>
-            <div className="relative flex items-center gap-4">
-              <p className="text-gray-400">Year:</p>
-              <FilterDropdown
-                itemList={years}
-                onSelectItem={(year) => setSelectedYear(year)}
-                currentlySelected={selectedYear}
-              />
-            </div>
-          </div>
-          <button
-            onClick={() => toggleOpenDialog(null)}
-            className="box-content p-3 border border-white rounded-full group hover:bg-white"
-          >
-            <X className="size-4 stroke-white group-hover:stroke-darkBg" />
-          </button>
-        </header>
-        <section className="flex flex-col items-center justify-center flex-grow gap-32">
-          <div className="flex flex-col items-center w-full gap-8">
-            <p className="text-2xl font-semibold text-gray-400">Genres</p>
-            <div className="flex flex-wrap justify-center px-8 gap-x-4 gap-y-5">
-              {genres.map((genre) => (
-                <FilterPill
-                  key={genre}
-                  isSelected={selectedGenres.includes(genre)}
-                  label={genre}
-                  onClick={() =>
-                    selectedGenres.includes(genre)
-                      ? deselectGenre(genre)
-                      : selectGenre(genre)
-                  }
+      <div className="xl:max-w-[1200px] 1440:max-w-[1350px] 2xl:max-w-[1440px] mx-auto min-h-screen px-1 text-white flex flex-col pb-12 md:pb-0">
+        <button
+          onClick={() => toggleOpenDialog(null)}
+          className="box-content fixed self-end p-2 transition-colors border border-gray-400 rounded-full lg:p-3 top-5 right-3 w-fit group hover:bg-white"
+        >
+          <X className="size-4 lg:size-5 stroke-gray-400 group-hover:stroke-darkBg" />
+        </button>
+        <div className="flex flex-col justify-center flex-grow pt-16 md:pt-0 gap-14 md:gap-16 lg:gap-20">
+          <div className="flex items-center justify-center w-full pt-8 md:pt-0">
+            <div className="flex flex-wrap justify-center gap-6 text-xs xl:text-base mobile-m:px-2 sm:px-2 md:px-3 md:text-sm">
+              <div className="relative flex flex-col items-center gap-4">
+                <p className="text-gray-400">Sort By:</p>
+                <FilterDropdown
+                  itemList={sortBys}
+                  onSelectItem={(sortBy) => setSelectedSortBy(sortBy)}
+                  labelMap={sortByLabels}
+                  currentlySelected={selectedSortBy}
                 />
-              ))}
+              </div>
+              <div className="relative flex flex-col items-center gap-4">
+                <p className="text-gray-400">Type:</p>
+                <FilterDropdown
+                  itemList={formats}
+                  onSelectItem={(format) => setSelectedFormat(format)}
+                  labelMap={formatLabels}
+                  currentlySelected={selectedFormat}
+                />
+              </div>
+              <div className="relative flex flex-col items-center gap-4">
+                <p className="text-gray-400">Status:</p>
+                <FilterDropdown
+                  itemList={statuses}
+                  labelMap={anilistAnimeStatusLabels}
+                  onSelectItem={(status) => setSelectedStatus(status)}
+                  currentlySelected={selectedStatus}
+                />
+              </div>
+              <div className="relative flex flex-col items-center gap-4">
+                <p className="text-gray-400">Season:</p>
+                <FilterDropdown
+                  itemList={seasons}
+                  onSelectItem={(season) => setSelectedSeason(season)}
+                  labelMap={seasonLabels}
+                  currentlySelected={selectedSeason}
+                />
+              </div>
+              <div className="relative flex flex-col items-center gap-4">
+                <p className="text-gray-400">Year:</p>
+                <FilterDropdown
+                  itemList={years}
+                  onSelectItem={(year) => setSelectedYear(year)}
+                  currentlySelected={selectedYear}
+                />
+              </div>
             </div>
           </div>
-          <div className="flex gap-5">
-            <button
-              onClick={() => clearFilters()}
-              className="px-5 py-3 text-gray-200 bg-gray-500 rounded-full"
-            >
-              <p>Clear Filters</p>
-            </button>
-            <button
-              onClick={() => applyFilters()}
-              className="px-5 py-3 rounded-full bg-mainAccent"
-            >
-              <p>Apply Filters</p>
-            </button>
-          </div>
-        </section>
+          <section className="flex flex-col items-center justify-center gap-16">
+            <div className="flex flex-col items-center w-full gap-6 px-2">
+              <p className="font-semibold text-gray-400 xl:text-2xl sm:text-base md:text-lg lg:text-xl">
+                Genres
+              </p>
+              <div className="flex flex-wrap justify-center gap-x-2 max-w-[1100px] px-4 gap-y-3 md:gap-x-3 md:gap-y-4">
+                {genres.map((genre) => (
+                  <FilterPill
+                    className="px-3 py-2 text-xs md:text-sm mobile-m:px-4 mobile-m:py-3 md:px-5 md:py-3 xl:text-base"
+                    key={genre}
+                    isSelected={selectedGenres.includes(genre)}
+                    label={genre}
+                    onClick={() =>
+                      selectedGenres.includes(genre)
+                        ? deselectGenre(genre)
+                        : selectGenre(genre)
+                    }
+                  />
+                ))}
+              </div>
+            </div>
+            <div className="flex gap-5 text-sm lg:text-base">
+              <button
+                onClick={() => clearFilters()}
+                className="px-4 py-3 text-gray-200 bg-gray-500 rounded-full lg:px-5 lg:py-3"
+              >
+                <p>Clear Filters</p>
+              </button>
+              <button
+                onClick={() => applyFilters()}
+                className="px-4 py-3 text-gray-200 transition-colors border rounded-full border-mainAccent hover:text-mainAccent lg:px-5 lg:py-3"
+              >
+                <p>Apply Filters</p>
+              </button>
+            </div>
+          </section>
+        </div>
       </div>
     </div>
   );

--- a/src/routes/anime/catalog/index.tsx
+++ b/src/routes/anime/catalog/index.tsx
@@ -4,7 +4,12 @@ import { SlidersHorizontal } from "lucide-react";
 import { z } from "zod";
 import CatalogAnimeList from "./-CatalogAnimeList";
 import AppliedFilters from "./-AppliedFilters";
-import { AnilistAnimeStatus, Format, Season, SortBy } from "@/utils/types/animeAnilist";
+import {
+  AnilistAnimeStatus,
+  Format,
+  Season,
+  SortBy,
+} from "@/utils/types/animeAnilist";
 import { useGlobalStore } from "@/utils/stores/globalStore";
 import FiltersDialog from "./-FiltersDialog";
 
@@ -16,27 +21,27 @@ const filterPageSearchSchema = z.object({
   year: z.number().optional(),
   sortBy: z.nativeEnum(SortBy).optional(),
   format: z.nativeEnum(Format).optional(),
-  status: z.nativeEnum(AnilistAnimeStatus).optional()
+  status: z.nativeEnum(AnilistAnimeStatus).optional(),
 });
 
-type FilterPageSearchParams = z.infer<typeof filterPageSearchSchema>
+type FilterPageSearchParams = z.infer<typeof filterPageSearchSchema>;
 
 export const Route = createFileRoute("/anime/catalog/")({
   component: () => <FilterPage />,
-  validateSearch: (search) : FilterPageSearchParams => {
-    const validationResult = filterPageSearchSchema.safeParse(search)
-    if(validationResult.success) {
-      return validationResult.data
+  validateSearch: (search): FilterPageSearchParams => {
+    const validationResult = filterPageSearchSchema.safeParse(search);
+    if (validationResult.success) {
+      return validationResult.data;
+    } else {
+      return {};
     }
-    else{
-      return {}
-    }
-  }
+  },
 });
 
 function FilterPage() {
-  const { format, genres, page, query, season, sortBy, year, status } = Route.useSearch();
-  const {toggleOpenDialog} = useGlobalStore()
+  const { format, genres, page, query, season, sortBy, year, status } =
+    Route.useSearch();
+  const { toggleOpenDialog } = useGlobalStore();
   const {
     data: filteredAnimes,
     isLoading: isFilteredAnimesLoading,
@@ -74,21 +79,29 @@ function FilterPage() {
 
   if (filteredAnimes) {
     return (
-      <main className="w-full text-[#f6f4f4] pt-32 pb-28 px-16 flex flex-col gap-10">
-        <div className="space-y-3">
-          <div className="flex justify-between">
-            <h1 className="text-2xl font-medium">Anime Catalog</h1>
-            <button onClick={() => toggleOpenDialog(<FiltersDialog/>)} className="flex items-center gap-2 px-5 py-2 border rounded-full group border-mainAccent">
-              <p className="font-medium transition-colors group-hover:text-mainAccent">Filter</p>
-              <SlidersHorizontal className="transition-colors size-4 group-hover:stroke-mainAccent" strokeWidth={3} />
+      <main className="w-full min-h-screen text-[#f6f4f4] pt-32 pb-28 px-3 sm:px-6 lg:px-16 flex flex-col gap-10">
+        <header className="space-y-7 lg:space-y-8">
+          <div className="flex items-center justify-between">
+            <h1 className="text-lg font-semibold sm:text-xl md:text-2xl">Discover Animes</h1>
+            <button
+              onClick={() => toggleOpenDialog(<FiltersDialog />)}
+              className="flex items-center gap-2 px-3 py-2 border rounded-full mobile-l:gap-3 mobile-l:px-4 md:px-5 md:py-3 group border-mainAccent"
+            >
+              <p className="text-xs font-medium transition-colors mobile-l:text-sm md:text-base group-hover:text-mainAccent">
+                Filter
+              </p>
+              <SlidersHorizontal
+                className="transition-colors size-3 sm:size-4 group-hover:stroke-mainAccent"
+                strokeWidth={3}
+              />
             </button>
           </div>
           <AppliedFilters />
-        </div>
+        </header>
         {filteredAnimes.results.length !== 0 ? (
           <CatalogAnimeList animeList={filteredAnimes.results} />
         ) : (
-          <div className="grid h-[40dvh] text-lg place-items-center">
+          <div className="grid flex-grow text-base text-center md:text-lg place-items-center">
             Sorry, we could not find the Anime you were looking for.
           </div>
         )}

--- a/src/utils/functions/reusable_functions.ts
+++ b/src/utils/functions/reusable_functions.ts
@@ -33,9 +33,9 @@ export function getEpisodesToBeRendered(
   const gogoAnimeData = animeInfoAnify?.episodes.data.find(
     (epData) => epData.providerId === "gogoanime"
   );
-  const animePaheData = animeInfoAnify?.episodes.data.find(
-    (epData) => epData.providerId === "animepahe"
-  );
+  // const animePaheData = animeInfoAnify?.episodes.data.find(
+  //   (epData) => epData.providerId === "animepahe"
+  // );
   const zoroData = animeInfoAnify?.episodes.data.find(
     (epData) => epData.providerId === "zoro"
   );
@@ -51,14 +51,24 @@ export function getEpisodesToBeRendered(
       id: ep.id,
       number: ep.number,
 
-      //get episode images from animepahe
-      image:
-        animePaheData && animePaheData.episodes[i]
-          ? animePaheData.episodes[i].img : animeInfoAnilist?.cover,
+      // ! since (9/8/24) this method of getting episode image doesnt work
+      // ! requesting animePahe images returns 403 forbidden, (might be CORS)
+      // image:
+      //   animePaheData && animePaheData.episodes[i]
+      //     ? animePaheData.episodes[i].img : animeInfoAnilist?.cover,
+
+      // ! currently this is the way.
+      // ! we just hope anilist gives us episode images 🙏
+      //get episode images from anilist, if none, just the default image
+      image: anilistEpisodes
+        ? anilistEpisodes[i].image
+        : animeInfoAnilist?.cover ?? animeInfoAnify?.coverImage,
+
       //get episode titles from zoro
       title:
         zoroData && zoroData.episodes[i]
-          ? zoroData.episodes[i].title : ep.title,
+          ? zoroData.episodes[i].title
+          : ep.title,
     }));
   } else if (anilistEpisodes && anilistEpisodes.length !== 0) {
     return anilistEpisodes.map((ep) => ({
@@ -71,4 +81,10 @@ export function getEpisodesToBeRendered(
     //else, accept the fact that the selected anime has no episodes
     return null;
   }
+}
+
+export function getRatingScore(rating: number) {
+  const decimal = (rating * 10).toString().split(".")[1];
+  if (!decimal || decimal.length < 1) return (0.05 * (rating * 10)).toFixed(1);
+  return (0.05 * (rating * 10)).toFixed(2);
 }

--- a/src/utils/stores/globalStore.tsx
+++ b/src/utils/stores/globalStore.tsx
@@ -19,7 +19,7 @@ const globalStoreDefaultValues: GlobalStoreValues = {
 };
 
 export const useGlobalStore = create<GlobalStore>(
-  (set, get) => ({
+  (set) => ({
     ...globalStoreDefaultValues,
     toggleOpenDialog: (dialogContent: ReactNode | null) => {
       if (dialogContent) {

--- a/src/utils/types/animeAnilist.ts
+++ b/src/utils/types/animeAnilist.ts
@@ -236,6 +236,7 @@ export enum Status {
   NOT_YET_RELEASED = "NOT_YET_RELEASED",
   CANCELLED = "CANCELLED",
   HIATUS = "HIATUS",
+  Cancelled = "Cancelled"
 }
 
 export type Relation = {

--- a/src/utils/types/animeAnizip.ts
+++ b/src/utils/types/animeAnizip.ts
@@ -1,0 +1,29 @@
+
+export type AnimeInfoAnizip = {
+  titles: Titles;
+  episodes: Episodes;
+  episodeCount: number;
+  specialCount: number;
+  images: Image[];
+};
+
+export type Episodes = {
+  [episodeNumber: string]: Episode;
+};
+
+export type Episode = {
+  episodeNumber: number;
+  title: {en: string};
+  overview: string;
+  image: string;
+};
+
+export type Image = {
+  coverType: string;
+  url: string;
+};
+
+export type Titles = {
+  ja: string;
+  en: string;
+};

--- a/src/utils/variables/anime.ts
+++ b/src/utils/variables/anime.ts
@@ -1,4 +1,4 @@
-import { Format, Season, SortBy, AnilistAnimeStatus } from "../types/animeAnilist";
+import { Format, Season, SortBy, AnilistAnimeStatus, Status } from "../types/animeAnilist";
 
 export const sortByLabels: Record<string, string> = {
   [SortBy.TRENDING_DESC]: "Trending",
@@ -21,11 +21,23 @@ export const formatLabels: Record<string, string> = {
 };
 
 export const anilistAnimeStatusLabels: Record<string, string> = {
-  [AnilistAnimeStatus.RELEASING]: "Releasing",
-  [AnilistAnimeStatus.FINISHED]: "Finished",
-  [AnilistAnimeStatus.NOT_YET_RELEASED]: "Not Yet Aired",
+  [AnilistAnimeStatus.RELEASING]: "Ongoing",
+  [AnilistAnimeStatus.FINISHED]: "Completed",
+  [AnilistAnimeStatus.NOT_YET_RELEASED]: "Upcoming",
   [AnilistAnimeStatus.CANCELLED]: "Cancelled",
 };
+
+export const statusLabels: Record<string, string> = {
+  [Status.RELEASING]: "Ongoing",
+  [Status.Ongoing]: "Ongoing",
+  [Status.FINISHED]: "Completed",
+  [Status.Completed]: "Completed",
+  [Status.NotYetAired]: "Upcoming",
+  [Status.NOT_YET_RELEASED]: "Upcoming",
+  [Status.CANCELLED]: "Cancelled",
+  [Status.HIATUS]: "Hiatus",
+};
+
 
 export const seasonLabels: Record<string, string> = {
   [Season.WINTER]: "Winter",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -23,6 +23,7 @@ module.exports = {
       screens: {
         "mobile-m" : "375px",
         "mobile-l" : "425px",
+        "1440": "1440px",
         "570": "570px"
       },
       colors: {


### PR DESCRIPTION
#17
In this PR I:

- added responsiveness for anime catalog page and filter dialog
- added Status filter labels
- finalized SearchDialogResultCard layout
- added text-highlight to selected item in FilterDropdown menu list
- added classname props to FilterPill
- changed the way episode images are taken in reusable_functions in getEpisodesToBeRendered(). It is now taken from anilist episodes, because anify's animepahe returns 403 forbidden.
- added types of new anime api: anizip
- changed logic of conditional classes of anime's status in AnimeHeroComponent from || operator to using cn() with Array.includes()
- changed GlobalDiaog z index to 200, added font to GlobalDialog, added vanilla css class called hide-scrollbar which does as it says in its name
- removed useFetchAnimeInfo(), went back with useFetchInfoAnify() and useFetchInfoAnilist(). I realized doing the former would result in an entire query error even if only one of the fetches returned an error.
- added useQuery hook: useFetchAnimeInfoAnizip, which fetches anime info from anizip api

…ime info from anizip api