### PR TITLE
feat: catalog page pagination

### DIFF
--- a/src/components/global/Pagination.tsx
+++ b/src/components/global/Pagination.tsx
@@ -1,0 +1,96 @@
+import usePagination from "@mui/material/usePagination";
+import { cn } from "@/lib/utils";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { forwardRef, ButtonHTMLAttributes } from "react";
+
+type PaginationProps = {
+  totalPages: number;
+  currentPage: number;
+  handlePageChange: (e: React.ChangeEvent<unknown>, page: number) => void;
+  className?: string;
+};
+
+type PaginationButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
+  isSelected: boolean;
+};
+
+const PaginationButton = forwardRef<HTMLButtonElement, PaginationButtonProps>(
+  ({ className, children, isSelected, ...props }, ref) => {
+    return (
+      <button
+        ref={ref}
+        className={cn(
+          "bg-gray-700 font-medium size-10 text-sm mobile-m:size-12 mobile-m:text-base grid place-items-center transition-colors duration-100 rounded-full hover:border-mainAccent hover:bg-mainAccent",
+          { "bg-mainAccent": isSelected },
+          className
+        )}
+        {...props}
+      >
+        {children}
+      </button>
+    );
+  }
+);
+
+export default function Pagination({
+  totalPages,
+  currentPage,
+  handlePageChange,
+  className,
+}: PaginationProps) {
+  const { items } = usePagination({
+    onChange: handlePageChange,
+    count: totalPages,
+    page: currentPage,
+  });
+
+  return (
+    <nav className={className}>
+      <ul className="flex flex-wrap items-center justify-center w-full gap-2 px-2">
+        {items.map((item, index) => {
+          const { page, selected, type } = item;
+          let child = null;
+
+          if (type === "start-ellipsis" || type === "end-ellipsis") {
+            child = "…";
+          } else if (type === "page") {
+            child = (
+              <PaginationButton
+                type="button"
+                isSelected={selected}
+                onClick={item.onClick}
+                disabled={item.disabled || selected}
+              >
+                {page}
+              </PaginationButton>
+            );
+          } else {
+            if (
+              (type === "previous" && currentPage === 1) ||
+              (type === "next" && currentPage === totalPages)
+            ) {
+              child = null;
+            } else {
+              child = (
+                <PaginationButton
+                  type="button"
+                  isSelected={selected}
+                  onClick={item.onClick}
+                  disabled={item.disabled || selected}
+                >
+                  {type === "previous" ? (
+                    <ChevronLeft className="size-6 stroke-white" />
+                  ) : (
+                    <ChevronRight className="size-6 stroke-white" />
+                  )}
+                </PaginationButton>
+              );
+            }
+          }
+
+          return <li key={index}>{child}</li>;
+        })}
+      </ul>
+    </nav>
+  );
+}

--- a/src/routes/anime/-AnimeCard.tsx
+++ b/src/routes/anime/-AnimeCard.tsx
@@ -94,8 +94,9 @@ export default function AnimeCard(props: AnimeCardProps) {
               props.recommendation.title.romaji}
           </p>
           <div className="flex items-center gap-2 text-xs text-gray-400">
-            {props.recommendation.status === Status.NotYetAired ||
-            props.recommendation.status === Status.NOT_YET_RELEASED ? (
+            {[Status.NotYetAired, Status.NOT_YET_RELEASED].includes(
+              props.recommendation.status
+            ) ? (
               <p className="line-clamp-1">Not yet aired</p>
             ) : (
               <>

--- a/src/routes/anime/catalog/-AppliedFilterPill.tsx
+++ b/src/routes/anime/catalog/-AppliedFilterPill.tsx
@@ -1,17 +1,23 @@
 // import { X } from "lucide-react"
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 type FilterPillProps = {
-    onDelete: () => void
-    className: string
-    label: string
-}
+  className: string;
+  label: string;
+};
 
-export default function AppliedFilterPill({className, label} : FilterPillProps) {
-    return (
-        <div className={cn("px-4 py-2 flex gap-3 rounded-full whitespace-nowrap text-xs md:text-sm lg:text-base items-center", className)}>
-            <p>{label}</p>
-            {/* <X className="size-4" onClick={onDelete}/> */}
-        </div>
-    )
+export default function AppliedFilterPill({
+  className,
+  label,
+}: FilterPillProps) {
+  return (
+    <div
+      className={cn(
+        "px-4 py-2 flex rounded-full whitespace-nowrap text-xs md:text-sm lg:text-base items-center justify-center",
+        className
+      )}
+    >
+      <p>{label}</p>
+    </div>
+  );
 }

--- a/src/routes/anime/catalog/-AppliedFilters.tsx
+++ b/src/routes/anime/catalog/-AppliedFilters.tsx
@@ -8,9 +8,10 @@ import {
 } from "@/utils/variables/anime";
 
 export default function AppliedFilters() {
-  const { genres, query, format, season, sortBy, year, status } = useSearch({
-    from: "/anime/catalog/",
-  });
+  const { genres, query, format, season, sortBy, year, status } =
+    useSearch({
+      from: "/anime/catalog/",
+    });
 
   return (
     <div className="flex w-full gap-4 overflow-x-auto hide-scrollbar sm:overflow-x-visible sm:flex-wrap">
@@ -22,7 +23,6 @@ export default function AppliedFilters() {
           <AppliedFilterPill
             className="text-white rounded-full bg-emerald-500"
             label={query}
-            onDelete={() => {}}
           />
         </div>
       )}
@@ -37,7 +37,7 @@ export default function AppliedFilters() {
                 key={genre}
                 className="text-white bg-blue-500 rounded-full"
                 label={genre}
-                onDelete={() => {}}
+  
               />
             ))}
           </div>
@@ -51,7 +51,6 @@ export default function AppliedFilters() {
           <AppliedFilterPill
             className="text-white bg-pink-600 rounded-full"
             label={sortByLabels[sortBy]}
-            onDelete={() => {}}
           />
         </div>
       )}
@@ -63,7 +62,6 @@ export default function AppliedFilters() {
           <AppliedFilterPill
             className="text-white bg-orange-500 rounded-full"
             label={formatLabels[format]}
-            onDelete={() => {}}
           />
         </div>
       )}
@@ -75,7 +73,6 @@ export default function AppliedFilters() {
           <AppliedFilterPill
             className="text-white rounded-full bg-lime-600"
             label={anilistAnimeStatusLabels[status]}
-            onDelete={() => {}}
           />
         </div>
       )}
@@ -87,7 +84,6 @@ export default function AppliedFilters() {
           <AppliedFilterPill
             className="text-white rounded-full bg-sky-500"
             label={year.toString()}
-            onDelete={() => {}}
           />
         </div>
       )}
@@ -99,7 +95,6 @@ export default function AppliedFilters() {
           <AppliedFilterPill
             className="text-white bg-teal-500 rounded-full"
             label={seasonLabels[season]}
-            onDelete={() => {}}
           />
         </div>
       )}

--- a/src/routes/anime/catalog/index.tsx
+++ b/src/routes/anime/catalog/index.tsx
@@ -1,5 +1,5 @@
 import { useFilterAnime } from "@/api/animes";
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { SlidersHorizontal } from "lucide-react";
 import { z } from "zod";
 import CatalogAnimeList from "./-CatalogAnimeList";
@@ -12,6 +12,7 @@ import {
 } from "@/utils/types/animeAnilist";
 import { useGlobalStore } from "@/utils/stores/globalStore";
 import FiltersDialog from "./-FiltersDialog";
+import Pagination from "@/components/global/Pagination";
 
 const filterPageSearchSchema = z.object({
   page: z.number().optional(),
@@ -41,6 +42,7 @@ export const Route = createFileRoute("/anime/catalog/")({
 function CatalogPage() {
   const { format, genres, page, query, season, sortBy, year, status } =
     Route.useSearch();
+  const navigate = useNavigate();
   const { toggleOpenDialog } = useGlobalStore();
   const {
     data: filteredAnimes,
@@ -79,7 +81,7 @@ function CatalogPage() {
 
   if (filteredAnimes) {
     return (
-      <main className="w-full min-h-screen text-[#f6f4f4] pt-32 pb-28 flex flex-col gap-10">
+      <main className="w-full min-h-screen text-[#f6f4f4] pt-32 pb-28 flex flex-col gap-6">
         <header className="space-y-7 lg:space-y-8">
           <div className="flex items-center justify-between">
             <h1 className="text-lg font-semibold sm:text-xl md:text-2xl">
@@ -101,7 +103,19 @@ function CatalogPage() {
           <AppliedFilters />
         </header>
         {filteredAnimes.results.length !== 0 ? (
-          <CatalogAnimeList animeList={filteredAnimes.results} />
+          <>
+            <CatalogAnimeList animeList={filteredAnimes.results} />
+            <Pagination
+              className="mt-10"
+              totalPages={filteredAnimes.totalPages}
+              currentPage={filteredAnimes.currentPage}
+              handlePageChange={(_, page) => {
+                navigate({
+                  search: (prev) => ({ ...prev, page: page }),
+                });
+              }}
+            />
+          </>
         ) : (
           <div className="grid flex-grow text-base text-center md:text-lg place-items-center">
             Sorry, we could not find the Anime you were looking for.

--- a/src/utils/functions/reusable_functions.ts
+++ b/src/utils/functions/reusable_functions.ts
@@ -49,7 +49,7 @@ export function getEpisodesToBeRendered(
             : null,
         title:
           animeInfoAnizip && animeInfoAnizip?.episodes[ep.number]
-            ? animeInfoAnizip?.episodes[ep.number].title.en
+            ? animeInfoAnizip?.episodes[ep.number].title.en || `EP ${ep.number}`
             : `EP ${ep.number}`,
       };
     });
@@ -66,7 +66,7 @@ export function getEpisodesToBeRendered(
             : undefined,
         title:
           animeInfoAnizip && animeInfoAnizip?.episodes[ep.number]
-            ? animeInfoAnizip?.episodes[ep.number].title.en
+            ? animeInfoAnizip?.episodes[ep.number].title.en || `EP ${ep.number}`
             : `EP ${ep.number}`,
       };
     });


### PR DESCRIPTION
#17
In this PR I:

- created a reusable Pagination component using material UI's usePagination. It takes the total number of pages, the current page, and a handlePageChange callback that is triggered when a pagination button is clicked.
- created reusable component PaginationButton for the Pagination component, this button contains all the default styling for the Pagination component's button. I made this to avoid rewriting the same styles over and over again for each button.
- removed onDelete prop in AppliedFilterPill
- changed logic for retrieving episode title in getEpisodesToBeRendered()