### PR TITLE
feat: anime info section in watch episode page

### DIFF
--- a/src/api/animes.ts
+++ b/src/api/animes.ts
@@ -117,7 +117,7 @@ export function useFetchAnimeInfo(animeId: string) {
           .catch(() => null),
         axios
           .get(
-            `${import.meta.env.VITE_ANIFY_URL}/info/${animeId}?fields=[bannerImage,coverImage,title,rating,trailer,description,id,totalEpisodes,year,status,format]`
+            `${import.meta.env.VITE_ANIFY_URL}/info/${animeId}?fields=[genres,bannerImage,coverImage,title,rating,trailer,description,id,totalEpisodes,year,status,format]`
           )
           .catch(() => null),
       ]);

--- a/src/routes/anime/$animeId/-Episodes.tsx
+++ b/src/routes/anime/$animeId/-Episodes.tsx
@@ -58,7 +58,7 @@ export default function Episodes({
   if (episodes && chunkedEpisodes) {
     if (isInfoPage) {
       return (
-        <div className="flex flex-col w-full pt-8 space-y-6 text-sm text-gray-400 lg:text-base">
+        <div className="flex flex-col w-full pt-8 mb-16 space-y-6 text-sm text-gray-400 lg:text-base">
           <div className="flex items-center justify-between">
             <p className="text-lg lg:text-xl font-semibold text-[#f6f4f4]">
               Episodes

--- a/src/routes/anime/$animeId/index.tsx
+++ b/src/routes/anime/$animeId/index.tsx
@@ -69,8 +69,8 @@ function AnimeInfoPage() {
           type={animeInfoAnilist?.type || animeInfoAnify?.format}
           year={animeInfoAnilist?.releaseDate || animeInfoAnify?.year}
           rating={
-            animeInfoAnilist?.rating! * 0.1 ??
-            animeInfoAnify?.rating.anilist ??
+            animeInfoAnilist?.rating * 0.1 ||
+            animeInfoAnify?.rating.anilist ||
             null
           }
         />

--- a/src/routes/anime/$animeId/index.tsx
+++ b/src/routes/anime/$animeId/index.tsx
@@ -4,6 +4,10 @@ import AnimeHeroComponent from "../-AnimeHeroComponent";
 import Episodes from "./-Episodes";
 import { useEffect } from "react";
 import AnimeCategoryCarousel from "../-AnimeCategoryCarousel";
+import { Genre } from "@/utils/types/animeAnilist";
+
+const anilistGenres = Object.values(Genre).map((genre) => genre.toString());
+
 export const Route = createFileRoute("/anime/$animeId/")({
   component: () => <AnimeInfoPage />,
 });
@@ -61,7 +65,13 @@ function AnimeInfoPage() {
           description={
             animeInfoAnilist?.description || animeInfoAnify?.description
           }
-          genres={animeInfoAnilist?.genres || undefined}
+          genres={
+            animeInfoAnilist?.genres || animeInfoAnify?.genres
+              ? animeInfoAnify?.genres.filter((genre) =>
+                  anilistGenres.includes(genre)
+                )
+              : undefined
+          }
           status={animeInfoAnilist?.status || animeInfoAnify?.status}
           totalEpisodes={
             animeInfoAnilist?.totalEpisodes || animeInfoAnify?.totalEpisodes
@@ -90,7 +100,6 @@ function AnimeInfoPage() {
         {animeInfoAnilist?.recommendations &&
           animeInfoAnilist?.recommendations.length !== 0 && (
             <AnimeCategoryCarousel
-              isInfoPage
               isHomePage={false}
               recommendations={animeInfoAnilist?.recommendations}
               categoryName="Recommendations"

--- a/src/routes/anime/$animeId/watch/-EpisodeAnimeInfo.tsx
+++ b/src/routes/anime/$animeId/watch/-EpisodeAnimeInfo.tsx
@@ -1,9 +1,12 @@
 import { useState, useEffect, useRef } from "react";
 import { motion } from "framer-motion";
 import { ChevronDown } from "lucide-react";
-import { Format, Status, Genre } from "@/utils/types/animeAnilist";
+import { Format, Status } from "@/utils/types/animeAnilist";
 import { getRatingScore } from "@/utils/functions/reusable_functions";
 import { statusLabels } from "@/utils/variables/anime";
+import { cn } from "@/lib/utils";
+import { useWindowWidth } from "@/utils/hooks/useWindowWidth";
+import { Link } from "@tanstack/react-router";
 
 type AnimeInfoProps = {
   cover: string | undefined;
@@ -14,7 +17,7 @@ type AnimeInfoProps = {
   year: number | undefined;
   type: Format | undefined;
   status: Status | undefined;
-  genres: Genre[] | undefined;
+  genres: string[] | undefined;
   rating: number | null | undefined;
 };
 
@@ -30,27 +33,36 @@ export default function EpisodeAnimeInfo({
   genres,
   rating,
 }: AnimeInfoProps) {
-  const [descriptionHeight, setDescriptionHeight] = useState(0);
-  const descriptionRef = useRef<HTMLDivElement | null>(null);
+  const [desktopDescriptionHeight, setDesktopDescriptionHeight] = useState(0);
+  const desktopDescriptionRef = useRef<HTMLDivElement | null>(null);
   const [readMore, setReadMore] = useState(false);
   const [starsFillWidthPercentage, setStarsFillWidthPercentage] = useState(0);
   const starsFillWidthRef = useRef<HTMLDivElement | null>(null);
+  const [mobileDesriptionHeight, setMobileDesriptionHeight] = useState(0);
+  const mobileDesriptionRef = useRef<HTMLDivElement | null>(null);
+
+  const windowWidth = useWindowWidth();
 
   useEffect(() => {
     if (starsFillWidthRef.current && rating) {
       setStarsFillWidthPercentage(rating * 10);
     }
-    if (descriptionRef.current) {
-      setDescriptionHeight(
-        descriptionRef.current.getBoundingClientRect().height
+    if (desktopDescriptionRef.current) {
+      setDesktopDescriptionHeight(
+        desktopDescriptionRef.current.getBoundingClientRect().height
       );
     }
-  }, []);
+    if (mobileDesriptionRef.current) {
+      setMobileDesriptionHeight(
+        mobileDesriptionRef.current.getBoundingClientRect().height
+      );
+    }
+  }, [windowWidth]);
 
   return (
-    <div className="relative flex justify-center w-full py-20 my-14">
-      <div className="absolute inset-0 size-full max-h-[600px] rounded-[inherit]">
-        <div className="absolute bg-black/65 size-full backdrop-blur-[1px] rounded-[inherit]"></div>
+    <main className="relative flex flex-col w-full gap-6 py-24 mb-10 justfy-center mt-14">
+      <div className="absolute inset-0 size-full max-h-[500px] rounded-[inherit]">
+        <div className="absolute bg-black/60 size-full backdrop-blur-[1px] rounded-[inherit]"></div>
         <div className="absolute bg-gradient-to-r from-darkBg from-[percentage:0%_1%] rounded-[inherit] via-transparent to-transparent size-full"></div>
         <div className="absolute bg-gradient-to-l from-darkBg from-[percentage:0%_1%] rounded-[inherit] via-transparent to-transparent size-full"></div>
         <div className="absolute bg-gradient-to-b from-darkBg from-[percentage:0%_1%] rounded-[inherit] via-transparent to-transparent size-full"></div>
@@ -60,72 +72,96 @@ export default function EpisodeAnimeInfo({
           className="object-cover rounded-[inherit] size-full"
         />
       </div>
-      <div className="flex gap-12 size-full">
-        <div className="aspect-[3/4] h-[280px] rounded-xl overflow-hidden z-10">
+      <div className="z-10 flex gap-3 sm:gap-5 md:gap-8 lg:gap-12 size-full">
+        <section className="aspect-[3/4] max-h-[180px] mobile-m:max-h-[190px] mobile-l:max-h-[200px] sm:max-h-[240px] md:max-h-[260px] lg:max-h-[300px] rounded-xl overflow-hidden z-10">
           <img src={image} className="object-cover size-full" />
-        </div>
-        <div className="z-10 flex flex-col flex-1 gap-3">
-          <p className="text-2xl font-semibold">{title}</p>
-          <div className="items-center hidden gap-4 ml-2 lg:flex lg:my-1">
-            <div
-              style={{
-                WebkitMaskImage: 'url("/five-stars.svg")',
-                WebkitMaskSize: "contain",
-                WebkitMaskRepeat: "no-repeat",
-                WebkitMaskPosition: "center",
-              }}
-              className="relative w-32 h-5 bg-gray-500 xl:h-6 lg:-ml-2"
-            >
+        </section>
+        <section className="z-10 flex flex-col flex-1 gap-2 sm:gap-3">
+          <p className="text-lg font-semibold sm:text-xl line-clamp-2 md:text-2xl">
+            {title}
+          </p>
+          <div className="flex flex-col gap-2 mobile-m:gap-4">
+            <div className="flex items-center gap-2 mobile-l:gap-4 xl:ml-2 lg:my-1">
               <div
-                ref={starsFillWidthRef}
                 style={{
-                  width: `${starsFillWidthPercentage}%`,
+                  WebkitMaskImage: 'url("/five-stars.svg")',
+                  WebkitMaskSize: "contain",
+                  WebkitMaskRepeat: "no-repeat",
+                  WebkitMaskPosition: "center",
                 }}
-                className={`absolute bg-amber-400 h-full`}
-              ></div>
+                className={cn(
+                  "relative w-20 h-full mobile-m:w-24 sm:w-28 bg-gray-500 lg:w-32 lg:h-5 xl:h-6 lg:-ml-2"
+                )}
+              >
+                <div
+                  ref={starsFillWidthRef}
+                  style={{
+                    width: `${starsFillWidthPercentage}%`,
+                  }}
+                  className={`absolute bg-amber-400 h-full`}
+                ></div>
+              </div>
+              <p className="text-xs font-semibold mobile-l:text-sm sm:text-base md:text-lg">
+                <span className="text-mainAccent">
+                  {rating ? `${getRatingScore(rating)}` : "?"}
+                </span>
+                /5
+              </p>
             </div>
-            <p className="text-lg font-semibold">
-              <span className="text-mainAccent">
-                {rating ? `${getRatingScore(rating)}` : "?"}
-              </span>
-              /5
-            </p>
-          </div>
-          <div className="flex items-center gap-8">
-            <div className="flex items-center gap-2">
-              <p className="text-gray-400">Year:</p>
-              <p>{year}</p>
+            <div className="flex flex-col items-start gap-2 text-xs sm:text-base mobile-m:gap-3 md:gap-4 lg:gap-8 lg:items-center lg:flex-row">
+              <div className="flex items-center gap-2">
+                <p className="text-gray-400">Year:</p>
+                <p>{year}</p>
+              </div>
+              <div className="flex items-center gap-2">
+                <p className="text-gray-400">Total Episodes:</p>
+                <p>{totalEpisodes}</p>
+              </div>
+              <div className="flex items-center gap-2">
+                <p className="text-gray-400">Status:</p>
+                {status && (
+                  <p
+                    className={cn("font-semibold text-orange-500", {
+                      "text-green-500": [
+                        Status.Ongoing,
+                        Status.RELEASING,
+                      ].includes(status),
+                      "text-blue-500": [
+                        Status.FINISHED,
+                        Status.Completed,
+                      ].includes(status),
+                      "text-red-500": [
+                        Status.CANCELLED,
+                        Status.Cancelled,
+                      ].includes(status),
+                    })}
+                  >
+                    {statusLabels[status as Status]}
+                  </p>
+                )}
+              </div>
+              <div className="flex items-center gap-2">
+                <p className="text-gray-400">Type:</p>
+                <p>{type}</p>
+              </div>
             </div>
-            <div className="flex items-center gap-2">
-              <p className="text-gray-400">Total Episodes:</p>
-              <p>{totalEpisodes}</p>
-            </div>
-            <div className="flex items-center gap-2">
-              <p className="text-gray-400">Status:</p>
-              <p className="text-blue-500">{statusLabels[status as Status]}</p>
-            </div>
-            <div className="flex items-center gap-2">
-              <p className="text-gray-400">Type:</p>
-              <p>{type}</p>
-            </div>
-          </div>
-          <div className="flex items-center gap-2">
-            <p className="text-gray-400">Genres:</p>
-            {genres ? (
-              <ul className="flex flex-wrap gap-3 text-sm">
-                {genres.map((genre) => (
-                  <button
+            <ul className="flex-wrap hidden gap-3 text-xs lg:flex lg:text-sm">
+              {genres &&
+                genres.map((genre) => (
+                  <Link
+                    to="/anime/catalog"
+                    search={{
+                      genres: genre,
+                    }}
                     key={genre}
-                    className="px-3 py-2 transition-colors border rounded-full border-mainAccent/60 hover:text-mainAccent"
+                    className="px-3 py-2 transition-colors border rounded-full border-mainAccent/90 hover:text-mainAccent"
                   >
                     {genre}
-                  </button>
+                  </Link>
                 ))}
-              </ul>
-            ) : <p>N/A</p>}
+            </ul>
           </div>
-          <div className="relative flex flex-col w-full gap-3 mt-5 lg:mt-0 lg:w-[75%] xl:w-[70%]">
-            <p className="text-lg font-semibold lg:hidden">Description</p>
+          <div className="relative lg:block hidden gap-3 mt-2 w-[75%]">
             <motion.div
               initial={{
                 height: "80px",
@@ -138,24 +174,24 @@ export default function EpisodeAnimeInfo({
               }}
               style={{
                 maskImage:
-                  readMore || descriptionHeight <= 80
+                  readMore || desktopDescriptionHeight <= 80
                     ? ""
                     : "linear-gradient(to bottom, white 1%, transparent)",
                 WebkitMaskImage:
-                  readMore || descriptionHeight <= 80
+                  readMore || desktopDescriptionHeight <= 80
                     ? ""
                     : "linear-gradient(to bottom, white 1%, transparent)",
               }}
               className="relative overflow-hidden text-gray-400"
             >
-              <p ref={descriptionRef}>
+              <p ref={desktopDescriptionRef}>
                 {`${description ? description.replace(/<[^>]*>/g, "") : "No Description"}`}
               </p>
             </motion.div>
-            {descriptionHeight > 80 && (
+            {desktopDescriptionHeight > 80 && (
               <motion.div
                 animate={{
-                  height: readMore ? `${descriptionHeight}px` : "80px",
+                  height: readMore ? `${desktopDescriptionHeight}px` : "80px",
                 }}
                 transition={{
                   duration: 0.2,
@@ -177,8 +213,77 @@ export default function EpisodeAnimeInfo({
               </motion.div>
             )}
           </div>
+        </section>
+      </div>
+      <div className="z-10 w-full space-y-4 lg:space-y-0">
+        <ul className="flex flex-wrap gap-2 text-xs lg:hidden mobile-m:gap-3 sm:text-sm">
+          {genres &&
+            genres.map((genre) => (
+              <Link
+                to="/anime/catalog"
+                search={{
+                  genres: genre,
+                }}
+                key={genre}
+                className="px-3 py-2 transition-colors border rounded-full border-mainAccent/75 hover:text-mainAccent/75"
+              >
+                {genre}
+              </Link>
+            ))}
+        </ul>
+        <div className="relative text-sm sm:text-base lg:hidden">
+          <motion.div
+            initial={{
+              height: "80px",
+            }}
+            animate={{
+              height: readMore ? "auto" : "80px",
+            }}
+            transition={{
+              duration: 0.2,
+            }}
+            style={{
+              maskImage:
+                readMore || mobileDesriptionHeight <= 80
+                  ? ""
+                  : "linear-gradient(to bottom, white 1%, transparent)",
+              WebkitMaskImage:
+                readMore || mobileDesriptionHeight <= 80
+                  ? ""
+                  : "linear-gradient(to bottom, white 1%, transparent)",
+            }}
+            className="relative overflow-hidden text-gray-400"
+          >
+            <p ref={mobileDesriptionRef}>
+              {`${description ? description.replace(/<[^>]*>/g, "") : "No Description"}`}
+            </p>
+          </motion.div>
+          {mobileDesriptionHeight > 80 && (
+            <motion.div
+              animate={{
+                height: readMore ? `${mobileDesriptionHeight}px` : "80px",
+              }}
+              transition={{
+                duration: 0.2,
+              }}
+              className="absolute w-full -bottom-3"
+            >
+              <button
+                onClick={() => setReadMore(!readMore)}
+                className="absolute left-0 flex gap-3 -bottom-6"
+              >
+                <p className="text-gray-400">
+                  {readMore ? "Read Less" : "Read More"}
+                </p>
+                <ChevronDown
+                  stroke="#9ca3af"
+                  className={`${readMore && "rotate-180"} duration-500 transition-transform`}
+                />
+              </button>
+            </motion.div>
+          )}
         </div>
       </div>
-    </div>
+    </main>
   );
 }

--- a/src/routes/anime/$animeId/watch/-EpisodeAnimeInfo.tsx
+++ b/src/routes/anime/$animeId/watch/-EpisodeAnimeInfo.tsx
@@ -1,0 +1,184 @@
+import { useState, useEffect, useRef } from "react";
+import { motion } from "framer-motion";
+import { ChevronDown } from "lucide-react";
+import { Format, Status, Genre } from "@/utils/types/animeAnilist";
+import { getRatingScore } from "@/utils/functions/reusable_functions";
+import { statusLabels } from "@/utils/variables/anime";
+
+type AnimeInfoProps = {
+  cover: string | undefined;
+  image: string | undefined;
+  title: string | undefined;
+  description: string | undefined;
+  totalEpisodes: number | undefined;
+  year: number | undefined;
+  type: Format | undefined;
+  status: Status | undefined;
+  genres: Genre[] | undefined;
+  rating: number | null | undefined;
+};
+
+export default function EpisodeAnimeInfo({
+  cover,
+  image,
+  description,
+  totalEpisodes,
+  year,
+  type,
+  title,
+  status,
+  genres,
+  rating,
+}: AnimeInfoProps) {
+  const [descriptionHeight, setDescriptionHeight] = useState(0);
+  const descriptionRef = useRef<HTMLDivElement | null>(null);
+  const [readMore, setReadMore] = useState(false);
+  const [starsFillWidthPercentage, setStarsFillWidthPercentage] = useState(0);
+  const starsFillWidthRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (starsFillWidthRef.current && rating) {
+      setStarsFillWidthPercentage(rating * 10);
+    }
+    if (descriptionRef.current) {
+      setDescriptionHeight(
+        descriptionRef.current.getBoundingClientRect().height
+      );
+    }
+  }, []);
+
+  return (
+    <div className="relative flex justify-center w-full py-20 my-14">
+      <div className="absolute inset-0 size-full max-h-[600px] rounded-[inherit]">
+        <div className="absolute bg-black/65 size-full backdrop-blur-[1px] rounded-[inherit]"></div>
+        <div className="absolute bg-gradient-to-r from-darkBg from-[percentage:0%_1%] rounded-[inherit] via-transparent to-transparent size-full"></div>
+        <div className="absolute bg-gradient-to-l from-darkBg from-[percentage:0%_1%] rounded-[inherit] via-transparent to-transparent size-full"></div>
+        <div className="absolute bg-gradient-to-b from-darkBg from-[percentage:0%_1%] rounded-[inherit] via-transparent to-transparent size-full"></div>
+        <div className="absolute bg-gradient-to-t from-darkBg from-[percentage:0%_1%] rounded-[inherit] via-transparent to-transparent size-full"></div>
+        <img
+          src={cover ?? image}
+          className="object-cover rounded-[inherit] size-full"
+        />
+      </div>
+      <div className="flex gap-12 size-full">
+        <div className="aspect-[3/4] h-[280px] rounded-xl overflow-hidden z-10">
+          <img src={image} className="object-cover size-full" />
+        </div>
+        <div className="z-10 flex flex-col flex-1 gap-3">
+          <p className="text-2xl font-semibold">{title}</p>
+          <div className="items-center hidden gap-4 ml-2 lg:flex lg:my-1">
+            <div
+              style={{
+                WebkitMaskImage: 'url("/five-stars.svg")',
+                WebkitMaskSize: "contain",
+                WebkitMaskRepeat: "no-repeat",
+                WebkitMaskPosition: "center",
+              }}
+              className="relative w-32 h-5 bg-gray-500 xl:h-6 lg:-ml-2"
+            >
+              <div
+                ref={starsFillWidthRef}
+                style={{
+                  width: `${starsFillWidthPercentage}%`,
+                }}
+                className={`absolute bg-amber-400 h-full`}
+              ></div>
+            </div>
+            <p className="text-lg font-semibold">
+              <span className="text-mainAccent">
+                {rating ? `${getRatingScore(rating)}` : "?"}
+              </span>
+              /5
+            </p>
+          </div>
+          <div className="flex items-center gap-8">
+            <div className="flex items-center gap-2">
+              <p className="text-gray-400">Year:</p>
+              <p>{year}</p>
+            </div>
+            <div className="flex items-center gap-2">
+              <p className="text-gray-400">Total Episodes:</p>
+              <p>{totalEpisodes}</p>
+            </div>
+            <div className="flex items-center gap-2">
+              <p className="text-gray-400">Status:</p>
+              <p className="text-blue-500">{statusLabels[status as Status]}</p>
+            </div>
+            <div className="flex items-center gap-2">
+              <p className="text-gray-400">Type:</p>
+              <p>{type}</p>
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            <p className="text-gray-400">Genres:</p>
+            {genres ? (
+              <ul className="flex flex-wrap gap-3 text-sm">
+                {genres.map((genre) => (
+                  <button
+                    key={genre}
+                    className="px-3 py-2 transition-colors border rounded-full border-mainAccent/60 hover:text-mainAccent"
+                  >
+                    {genre}
+                  </button>
+                ))}
+              </ul>
+            ) : <p>N/A</p>}
+          </div>
+          <div className="relative flex flex-col w-full gap-3 mt-5 lg:mt-0 lg:w-[75%] xl:w-[70%]">
+            <p className="text-lg font-semibold lg:hidden">Description</p>
+            <motion.div
+              initial={{
+                height: "80px",
+              }}
+              animate={{
+                height: readMore ? "auto" : "80px",
+              }}
+              transition={{
+                duration: 0.2,
+              }}
+              style={{
+                maskImage:
+                  readMore || descriptionHeight <= 80
+                    ? ""
+                    : "linear-gradient(to bottom, white 1%, transparent)",
+                WebkitMaskImage:
+                  readMore || descriptionHeight <= 80
+                    ? ""
+                    : "linear-gradient(to bottom, white 1%, transparent)",
+              }}
+              className="relative overflow-hidden text-gray-400"
+            >
+              <p ref={descriptionRef}>
+                {`${description ? description.replace(/<[^>]*>/g, "") : "No Description"}`}
+              </p>
+            </motion.div>
+            {descriptionHeight > 80 && (
+              <motion.div
+                animate={{
+                  height: readMore ? `${descriptionHeight}px` : "80px",
+                }}
+                transition={{
+                  duration: 0.2,
+                }}
+                className="absolute w-full -bottom-3"
+              >
+                <button
+                  onClick={() => setReadMore(!readMore)}
+                  className="absolute left-0 flex gap-3 -bottom-6"
+                >
+                  <p className="text-gray-400">
+                    {readMore ? "Read Less" : "Read More"}
+                  </p>
+                  <ChevronDown
+                    stroke="#9ca3af"
+                    className={`${readMore && "rotate-180"} duration-500 transition-transform`}
+                  />
+                </button>
+              </motion.div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/routes/anime/$animeId/watch/-EpisodeTitleAndNumber.tsx
+++ b/src/routes/anime/$animeId/watch/-EpisodeTitleAndNumber.tsx
@@ -1,0 +1,18 @@
+type EpisodeInfoProps = {
+  episodeNumber: string | undefined;
+  episodeTitle: string | undefined;
+};
+
+export default function EpisodeTitleAndNumber({
+  episodeNumber,
+  episodeTitle,
+}: EpisodeInfoProps) {
+  return (
+    <div className="flex flex-col w-full gap-1 mt-2 lg:px-0">
+      <p className="text-lg font-semibold sm:text-xl">
+        {episodeNumber}
+      </p>
+      <p className="font-medium text-gray-400 sm:text-lg line-clamp-1">{episodeTitle}</p>
+    </div>
+  );
+}

--- a/src/routes/anime/$animeId/watch/-VideoPlayer.tsx
+++ b/src/routes/anime/$animeId/watch/-VideoPlayer.tsx
@@ -1,0 +1,48 @@
+import { forwardRef, HTMLAttributes } from "react";
+import "@vidstack/react/player/styles/default/theme.css";
+import "@vidstack/react/player/styles/default/layouts/video.css";
+import { MediaPlayer, MediaProvider } from "@vidstack/react";
+import {
+  defaultLayoutIcons,
+  DefaultVideoLayout,
+} from "@vidstack/react/player/layouts/default";
+import { cn } from "@/lib/utils";
+
+type VideoPlayerProps = HTMLAttributes<HTMLDivElement> & {
+  streamLink: string | undefined;
+  className?: string;
+  volume?: number;
+  title?: string;
+};
+
+export const VideoPlayer = forwardRef<HTMLDivElement, VideoPlayerProps>(
+  ({ ...props }, ref) => {
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          "w-dvw ml-[calc(-50vw+50%)] lg:w-full lg:ml-auto aspect-video rounded-none",
+          props.className
+        )}
+      >
+        {props.streamLink ? (
+          <MediaPlayer
+            playsInline
+            className="rounded-none size-full"
+            title={props.title}
+            src={props.streamLink}
+            streamType="on-demand"
+            volume={props.volume || 0.08}
+          >
+            <MediaProvider />
+            <DefaultVideoLayout icons={defaultLayoutIcons} />
+          </MediaPlayer>
+        ) : (
+          <div className="grid text-lg font-medium size-full place-items-center">
+            Error: Source Not Found
+          </div>
+        )}
+      </div>
+    );
+  }
+);

--- a/src/routes/anime/$animeId/watch/index.tsx
+++ b/src/routes/anime/$animeId/watch/index.tsx
@@ -17,6 +17,9 @@ import {
   useEpisodeInfo,
 } from "@/api/animes";
 import EpisodeTitleAndNumber from "./-EpisodeTitleAndNumber";
+import { Genre } from "@/utils/types/animeAnilist";
+
+const anilistGenres = Object.values(Genre).map((genre) => genre.toString());
 
 const episodePageSearchParams = z.object({
   id: z.coerce.string(),
@@ -145,7 +148,13 @@ function WatchEpisodePage() {
           description={
             animeInfoAnilist?.description || animeInfoAnify?.description
           }
-          genres={animeInfoAnilist?.genres || undefined}
+          genres={
+            animeInfoAnilist?.genres || animeInfoAnify?.genres
+              ? animeInfoAnify?.genres.filter((genre) =>
+                  anilistGenres.includes(genre)
+                )
+              : undefined
+          }
           status={animeInfoAnilist?.status || animeInfoAnify?.status}
           totalEpisodes={
             animeInfoAnilist?.totalEpisodes || animeInfoAnify?.totalEpisodes
@@ -160,7 +169,6 @@ function WatchEpisodePage() {
         />
         {animeInfoAnilist?.recommendations && (
           <AnimeCategoryCarousel
-            isInfoPage={false}
             isHomePage={false}
             categoryName="Recommendations"
             recommendations={animeInfoAnilist?.recommendations}

--- a/src/routes/anime/$animeId/watch/index.tsx
+++ b/src/routes/anime/$animeId/watch/index.tsx
@@ -1,27 +1,22 @@
-import {
-  useChunkEpisodes,
-  useEpisodeInfo,
-  useFetchAnimeEpisodes,
-  useFetchAnimeInfo,
-  useFetchEpisodeStreamLinks,
-} from "@/api/animes";
-import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { createFileRoute } from "@tanstack/react-router";
+import { useNavigate } from "@tanstack/react-router";
 import { useEffect, useRef, useState } from "react";
 import "@vidstack/react/player/styles/default/theme.css";
 import "@vidstack/react/player/styles/default/layouts/video.css";
-import {
-  MediaPlayer,
-  MediaProvider,
-  MediaPlayerInstance,
-} from "@vidstack/react";
-import {
-  defaultLayoutIcons,
-  DefaultVideoLayout,
-} from "@vidstack/react/player/layouts/default";
 import Episodes from "../-Episodes";
 import AnimeCategoryCarousel from "../../-AnimeCategoryCarousel";
 import { z } from "zod";
 import { useWindowWidth } from "@/utils/hooks/useWindowWidth";
+import { VideoPlayer } from "./-VideoPlayer";
+import EpisodeAnimeInfo from "./-EpisodeAnimeInfo";
+import {
+  useFetchEpisodeStreamLinks,
+  useFetchAnimeEpisodes,
+  useFetchAnimeInfo,
+  useChunkEpisodes,
+  useEpisodeInfo,
+} from "@/api/animes";
+import EpisodeTitleAndNumber from "./-EpisodeTitleAndNumber";
 
 const episodePageSearchParams = z.object({
   id: z.coerce.string(),
@@ -36,7 +31,6 @@ function WatchEpisodePage() {
   const navigate = useNavigate();
   const { id } = Route.useSearch();
   const { animeId } = Route.useParams();
-  const mediaPlayerRef = useRef<MediaPlayerInstance | null>(null);
   const videoAndEpisodeInfoContainerRef = useRef<HTMLDivElement | null>(null);
   const [
     videoAndeEpisodeInfoContainerHeight,
@@ -106,49 +100,31 @@ function WatchEpisodePage() {
       <main className="flex flex-col pb-32">
         <section className="flex flex-col w-full gap-2 pt-20 lg:pt-24 lg:gap-6 lg:flex-row">
           <div ref={videoAndEpisodeInfoContainerRef} className="w-full h-fit">
-            <div className="w-dvw ml-[calc(-50vw+50%)] lg:w-full lg:ml-auto aspect-video rounded-none">
-              <MediaPlayer
-                ref={mediaPlayerRef}
-                playsInline
-                className="rounded-none size-full"
-                // title="Sprite Fight"
-                src={
-                  episodeStreamLinks.sources.find(
-                    (source) => source.quality === "backup"
-                  )?.url ??
-                  episodeStreamLinks.sources.find(
-                    (source) => source.quality === "default"
-                  )?.url
-                }
-                streamType="on-demand"
-                volume={0.08}
-              >
-                <MediaProvider />
-                <DefaultVideoLayout icons={defaultLayoutIcons} />
-              </MediaPlayer>
-            </div>
-            <div className="flex flex-col w-full gap-1 mt-2 lg:px-0">
-              <p className="text-lg font-bold sm:text-xl line-clamp-1">
-                {animeInfoAnilist?.title?.english ||
-                  animeInfoAnilist?.title?.romaji ||
-                  animeInfoAnify?.title.english ||
-                  animeInfoAnify?.title.romaji ||
-                  ""}
-              </p>
-              <p className="text-lg font-semibold text-gray-400 sm:text-xl">
-                {episodeInfo ? `Episode ${episodeInfo.number}` : "Loading..."}
-              </p>
-              {episodeInfo && (
-                <p className="font-medium sm:text-lg line-clamp-1">
-                  {episodeInfo.title}
-                </p>
-              )}
-            </div>
+            <VideoPlayer
+              streamLink={
+                episodeStreamLinks.sources.find(
+                  (source) => source.quality === "backup"
+                )?.url ??
+                episodeStreamLinks.sources.find(
+                  (source) => source.quality === "default"
+                )?.url
+              }
+              title={episodeInfo.title}
+            />
+            <EpisodeTitleAndNumber
+              episodeNumber={
+                episodeInfo ? `Episode ${episodeInfo.number}` : "Loading..."
+              }
+              episodeTitle={episodeInfo.title}
+            />
           </div>
           <Episodes
             episodeListMaxHeight={videoAndeEpisodeInfoContainerHeight}
             episodeImageFallback={
-              animeInfoAnilist?.cover || animeInfoAnilist?.image
+              animeInfoAnilist?.cover ||
+              animeInfoAnify?.coverImage ||
+              animeInfoAnilist?.image ||
+              animeInfoAnify?.bannerImage
             }
             episodesQuery={episodesQuery}
             isInfoPage={false}
@@ -157,6 +133,31 @@ function WatchEpisodePage() {
             type={animeInfoAnilist?.type || animeInfoAnify?.format}
           />
         </section>
+        <EpisodeAnimeInfo
+          title={
+            animeInfoAnilist?.title.english ||
+            animeInfoAnilist?.title.romaji ||
+            animeInfoAnify?.title.english ||
+            animeInfoAnify?.title.romaji
+          }
+          cover={animeInfoAnify?.bannerImage || animeInfoAnilist?.cover}
+          image={animeInfoAnilist?.image || animeInfoAnify?.coverImage}
+          description={
+            animeInfoAnilist?.description || animeInfoAnify?.description
+          }
+          genres={animeInfoAnilist?.genres || undefined}
+          status={animeInfoAnilist?.status || animeInfoAnify?.status}
+          totalEpisodes={
+            animeInfoAnilist?.totalEpisodes || animeInfoAnify?.totalEpisodes
+          }
+          type={animeInfoAnilist?.type || animeInfoAnify?.format}
+          year={animeInfoAnilist?.releaseDate || animeInfoAnify?.year}
+          rating={
+            animeInfoAnilist?.rating * 0.1 ||
+            animeInfoAnify?.rating.anilist ||
+            null
+          }
+        />
         {animeInfoAnilist?.recommendations && (
           <AnimeCategoryCarousel
             isInfoPage={false}

--- a/src/routes/anime/-AnimeCategoryCarousel.tsx
+++ b/src/routes/anime/-AnimeCategoryCarousel.tsx
@@ -88,7 +88,7 @@ export default function AnimeCategoryCarousel(
     );
   } else {
     return (
-      <div className="w-full pt-16 space-y-6 text-gray-400">
+      <div className="w-full space-y-6 text-gray-400">
         <p className="text-lg font-semibold sm:text-xl lg:text-2xl">
           {props.categoryName}
         </p>

--- a/src/routes/anime/-AnimeCategoryCarousel.tsx
+++ b/src/routes/anime/-AnimeCategoryCarousel.tsx
@@ -19,11 +19,7 @@ type HomePageProps = {
 type NotHomePageProps = {
   isHomePage: false;
   recommendations: Recommendation[];
-} & isInfoPage;
-
-type isInfoPage = {
-  isInfoPage: boolean;
-};
+}
 
 type AnimeCategoryCarouselProps = {
   categoryName: string;
@@ -35,7 +31,6 @@ export default function AnimeCategoryCarousel(
   if (props.isHomePage) {
     return (
       <div
-        // className="w-full px-3 pt-5 space-y-6 text-gray-400 lg:px-16 sm:px-6"
         className="w-full pt-5 space-y-6 text-gray-400"
       >
         <div className="flex items-center justify-between w-full">

--- a/src/routes/anime/-AnimeHeroComponent.tsx
+++ b/src/routes/anime/-AnimeHeroComponent.tsx
@@ -23,7 +23,6 @@ type AnimeHeroComponentProps = {
   year?: number;
   type?: Format;
   status?: Status;
-  trendingRank?: number;
   genres?: Genre[];
   rating?: number | null;
   animeId: string;
@@ -79,7 +78,7 @@ export default function AnimeHeroComponent({
           <p className="px-8 text-2xl font-semibold text-center lg:text-3xl lg:px-0 lg:text-start line-clamp-2">
             {title}
           </p>
-          <div className="items-center hidden gap-4 lg:flex lg:my-1">
+          <div className="items-center hidden gap-4 ml-2 lg:flex lg:my-1">
             <div
               style={{
                 WebkitMaskImage: 'url("/five-stars.svg")',

--- a/src/routes/anime/-AnimeHeroComponent.tsx
+++ b/src/routes/anime/-AnimeHeroComponent.tsx
@@ -23,7 +23,7 @@ type AnimeHeroComponentProps = {
   year?: number;
   type?: Format;
   status?: Status;
-  genres?: Genre[];
+  genres?: string[];
   rating?: number | null;
   animeId: string;
   episodesQuery: UseQueryResult<AnimeEpisodes, Error>;


### PR DESCRIPTION
In this PR I:

- implemented a responsive anime info section in watch episode page (below videoplayer and episodes)
- made the episode title and number a separate component (EpisodeTitleAndNumber.tsx)
- made video player a separate component (VideoPlayer.tsx)
- made the fallback anify 'genres' prop of AnimeHeroComponent and EpisodeAnimeInfo filtered to only include genres that are in the Genre enum
- in AnimeHeroComponent, replaced genres prop type from Genre[] to string[], for more flexibility.
- removed unnecessary isInfoPage prop in AnimeCategoryCarousel
- included genres in the fetch url of anify in useFetchAnimeInfo